### PR TITLE
Remove Auto Openapi Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Flanker is a web-app strategy game adaptation of Arty Concliffe's **_Crossfire_*
   cd frontend
   npm run dev-expose
   ```
-  **_Note:_** this will run `openapi-ts` that updates API type file `/frontend/src/lib/api-schema.d.ts`. Make sure that backend is running for this.
 
 ## Project Structure
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "npm run generate-api && vite dev",
-		"dev-expose": "npm run generate-api && vite dev --host",
+		"dev": "vite dev",
+		"dev-expose": "vite dev --host",
 		"build": "vite build",
 		"generate-api": "npx openapi-typescript http://127.0.0.1:8000/openapi.json -o ./src/lib/api-schema.d.ts",
 		"preview": "vite preview",


### PR DESCRIPTION
# Background
- Some time ago, I did #24 
- I added code to automatically generate ts types from openapi whenever I call npm script `dev`
- This is excessive. Removed.