### PR TITLE
Add Waypoint Interrupt

### DIFF
--- a/flanker-ai/src/flanker_ai/waypoints/models.py
+++ b/flanker-ai/src/flanker_ai/waypoints/models.py
@@ -15,16 +15,10 @@ class AbstractedCombatUnit:
 
 
 @dataclass
-class MovableNode:
-    move_to_id: int
-    path_nodes: list[int]
-
-
-@dataclass
 class WaypointNode:
     position: Vec2
     visible_nodes: list[int]
-    movable_nodes: list[MovableNode]
+    movable_paths: dict[int, list[int]]
 
 
 @dataclass
@@ -52,6 +46,7 @@ class WaypointFireAction:
 class WaypointAssaultAction:
     unit_id: int
     target_id: int
+    interrupt_at_id: int | None
 
 
 WaypointAction = WaypointMoveAction | WaypointFireAction | WaypointAssaultAction


### PR DESCRIPTION
# Changes
- continuation of #134 
- #142 
  - Add a small path-representation as a sequence of waypoints
  - During tree search, it chooses the best node along this path to represent move interrupt node.