### PR TITLE
Add Waypoints Pruning

### DIFF
--- a/flanker-ai/src/flanker_ai/config_models.py
+++ b/flanker-ai/src/flanker_ai/config_models.py
@@ -29,7 +29,7 @@ class WaypointsStateConfig:
     class ExpansionConfig:
         type: Literal["LineBased"] | Literal["Polygonal"]
         iterations: int
-        prune_frequency: int | None
+        prune_iterations: int
 
     type: Literal["WaypointsStateConfig"]
     points: GridConfig | HandDrawnConfig | VoronoiConfig

--- a/flanker-ai/src/flanker_ai/config_models.py
+++ b/flanker-ai/src/flanker_ai/config_models.py
@@ -29,6 +29,7 @@ class WaypointsStateConfig:
     class ExpansionConfig:
         type: Literal["LineBased"] | Literal["Polygonal"]
         iterations: int
+        prune_frequency: int | None
 
     type: Literal["WaypointsStateConfig"]
     points: GridConfig | HandDrawnConfig | VoronoiConfig

--- a/flanker-ai/src/flanker_ai/states/waypoints/waypoints_flag_service.py
+++ b/flanker-ai/src/flanker_ai/states/waypoints/waypoints_flag_service.py
@@ -1,0 +1,39 @@
+from flanker_core.gamestate import GameState
+from flanker_core.models.vec2 import Vec2
+from flanker_core.systems.los_system import LosSystem
+from flanker_core.utils.intersect_getter import IntersectGetter
+
+
+class WaypointsFlagService:
+    @staticmethod
+    def get_flags(
+        gs: GameState,
+        waypoint: Vec2,
+        all_waypoints: set[Vec2],
+    ) -> dict[Vec2, bool]:
+        """Return visibility flags of this waypoint against all other waypoints."""
+        los_system = gs.get(LosSystem)
+        waypoint_los_polygon = los_system.get_los_polygon(gs, waypoint)
+        return {
+            other_waypoint: IntersectGetter.is_inside(
+                other_waypoint, waypoint_los_polygon
+            )
+            for other_waypoint in all_waypoints
+        }
+
+    @staticmethod
+    def prune_waypoints(
+        gs: GameState,
+        waypoints: set[Vec2],
+    ) -> set[Vec2]:
+        """Removes waypoints that has duplicate flag values."""
+        unique_waypoints: set[Vec2] = set()
+        seen_flags: set[int] = set()
+        for waypoint in waypoints:
+            flags = WaypointsFlagService.get_flags(gs, waypoint, waypoints)
+            # Flags are not hashable by default, so hash this in a dedicated step
+            hashed_flags: int = hash(frozenset(flags.items()))
+            if hashed_flags not in seen_flags:
+                seen_flags.add(hashed_flags)
+                unique_waypoints.add(waypoint)
+        return unique_waypoints

--- a/flanker-ai/src/flanker_ai/states/waypoints/waypoints_generator_service.py
+++ b/flanker-ai/src/flanker_ai/states/waypoints/waypoints_generator_service.py
@@ -61,7 +61,7 @@ class WaypointsGeneratorService:
         gs: GameState,
         initial_waypoints: list[Vec2],
         iterations: int,
-        prune_frequency: int | None,
+        prune_iterations: int,
     ) -> list[Vec2]:
         """
         Given a list of waypoints, expand and create more waypoints
@@ -79,7 +79,7 @@ class WaypointsGeneratorService:
                 vertices.append(vertices[0])
             terrain_vertices.append(vertices)
 
-        for iteration in range(iterations):
+        for _ in range(iterations):
             processed_pair: list[tuple[Vec2, Vec2]] = []
 
             # Loop through each waypoint pair to consider new
@@ -138,6 +138,6 @@ class WaypointsGeneratorService:
             waypoints |= new_waypoints
 
             # Prune some waypoints to reduce combinatorial explosion
-            if prune_frequency and iteration % prune_frequency == 0:
+            for _ in range(prune_iterations):
                 waypoints = WaypointsFlagService.prune_waypoints(gs, waypoints)
         return list(waypoints)

--- a/flanker-ai/src/flanker_ai/states/waypoints/waypoints_generator_service.py
+++ b/flanker-ai/src/flanker_ai/states/waypoints/waypoints_generator_service.py
@@ -1,5 +1,6 @@
 from itertools import pairwise
 
+from flanker_ai.states.waypoints.waypoints_flag_service import WaypointsFlagService
 from flanker_core.gamestate import GameState
 from flanker_core.models.components import TerrainFeature, Transform
 from flanker_core.models.vec2 import Vec2
@@ -60,6 +61,7 @@ class WaypointsGeneratorService:
         gs: GameState,
         initial_waypoints: list[Vec2],
         iterations: int,
+        prune_frequency: int | None,
     ) -> list[Vec2]:
         """
         Given a list of waypoints, expand and create more waypoints
@@ -77,7 +79,7 @@ class WaypointsGeneratorService:
                 vertices.append(vertices[0])
             terrain_vertices.append(vertices)
 
-        for _ in range(iterations):
+        for iteration in range(iterations):
             processed_pair: list[tuple[Vec2, Vec2]] = []
 
             # Loop through each waypoint pair to consider new
@@ -134,4 +136,8 @@ class WaypointsGeneratorService:
 
             # The 'or' operator |= is set concat
             waypoints |= new_waypoints
+
+            # Prune some waypoints to reduce combinatorial explosion
+            if prune_frequency and iteration % prune_frequency == 0:
+                waypoints = WaypointsFlagService.prune_waypoints(gs, waypoints)
         return list(waypoints)

--- a/flanker-ai/src/flanker_ai/states/waypoints/waypoints_state_factory.py
+++ b/flanker-ai/src/flanker_ai/states/waypoints/waypoints_state_factory.py
@@ -41,6 +41,7 @@ class WaypointsStateFactory:
                         gs=gs,
                         initial_waypoints=points,
                         iterations=config.expansion.iterations,
+                        prune_frequency=config.expansion.prune_frequency,
                     )
                 case "Polygonal":
                     raise NotImplementedError()

--- a/flanker-ai/src/flanker_ai/states/waypoints/waypoints_state_factory.py
+++ b/flanker-ai/src/flanker_ai/states/waypoints/waypoints_state_factory.py
@@ -41,7 +41,7 @@ class WaypointsStateFactory:
                         gs=gs,
                         initial_waypoints=points,
                         iterations=config.expansion.iterations,
-                        prune_frequency=config.expansion.prune_frequency,
+                        prune_iterations=config.expansion.prune_iterations,
                     )
                 case "Polygonal":
                     raise NotImplementedError()

--- a/flanker-ai/tests/test_waypoints_expansion.py
+++ b/flanker-ai/tests/test_waypoints_expansion.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import override
 
-from flanker_core.systems.los_system import LosSystem
 import pytest
 from flanker_ai.states.waypoints.waypoints_generator_service import (
     WaypointsGeneratorService,
@@ -9,6 +8,7 @@ from flanker_ai.states.waypoints.waypoints_generator_service import (
 from flanker_core.gamestate import GameState
 from flanker_core.models.components import TerrainFeature, Transform
 from flanker_core.models.vec2 import Vec2
+from flanker_core.systems.los_system import LosSystem
 from flanker_core.systems.register_systems import register_systems
 
 
@@ -31,6 +31,7 @@ class MockLosSystem(LosSystem):
             Vec2(4, 12),
             Vec2(4, 8),
             Vec2(12, 8),
+            Vec2(12, 12),
         ]
 
 
@@ -94,6 +95,8 @@ def test_one_iteration(fixture: Fixture) -> None:
         gs=fixture.gs,
         initial_waypoints=fixture.waypoints_coodinates,
         iterations=1,
+        # There can't be any pruning since LOS is mocked.
+        prune_frequency=None,
     )
     assert set(fixture.waypoints_coodinates).issubset(
         new_waypoints

--- a/flanker-ai/tests/test_waypoints_expansion.py
+++ b/flanker-ai/tests/test_waypoints_expansion.py
@@ -96,7 +96,7 @@ def test_one_iteration(fixture: Fixture) -> None:
         initial_waypoints=fixture.waypoints_coodinates,
         iterations=1,
         # There can't be any pruning since LOS is mocked.
-        prune_frequency=None,
+        prune_iterations=0,
     )
     assert set(fixture.waypoints_coodinates).issubset(
         new_waypoints

--- a/scenes/experiment-grid.json
+++ b/scenes/experiment-grid.json
@@ -144,7 +144,8 @@
             },
             "expansion": {
               "type": "LineBased",
-              "iterations": 1
+              "iterations": 1,
+              "prune_frequency": 1
             },
             "path_tolerance": 30.0
           }

--- a/scenes/experiment-grid.json
+++ b/scenes/experiment-grid.json
@@ -145,7 +145,7 @@
             "expansion": {
               "type": "LineBased",
               "iterations": 1,
-              "prune_frequency": 1
+              "prune_iterations": 2
             },
             "path_tolerance": 30.0
           }


### PR DESCRIPTION
# Changes
- #202 
  - Add a flag mechanism to distinguish distinct waypoints
  - Add a pruning mechanism to waypoints expansion
  - The flags used are still very poor, and is not sufficient to run the expansion for more than a single iteration. Nevertheless, future improvements would come later.