### PR TITLE
Add JSON Scene Schema

### DIFF
--- a/flanker-ai/src/flanker_ai/components.py
+++ b/flanker-ai/src/flanker_ai/components.py
@@ -16,5 +16,7 @@ class AiStallCountComponent:
 
 @dataclass
 class AiConfigComponent:
+    """Configures that AI agent of that faction with policy and state."""
+
     config: SearchPolicyConfig | HeuristicPolicyConfig
     faction: InitiativeState.Faction

--- a/flanker-ai/src/flanker_ai/components.py
+++ b/flanker-ai/src/flanker_ai/components.py
@@ -16,7 +16,10 @@ class AiStallCountComponent:
 
 @dataclass
 class AiConfigComponent:
-    """Configures that AI agent of that faction with policy and state."""
+    """
+    Configures AI agent of either BLUE or RED with search policy and state.
+    Supports search-based policy or heuristic rule-based policy.
+    """
 
     config: SearchPolicyConfig | HeuristicPolicyConfig
     faction: InitiativeState.Faction

--- a/flanker-core/src/flanker_core/serializer.py
+++ b/flanker-core/src/flanker_core/serializer.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Optional
 from uuid import UUID
 
@@ -28,6 +29,14 @@ class Serializer:
             "EntitiesTable", __base__=Serializer.EntitiesTable[Entity]
         )
         return Entity, EntitiesTable
+
+    @staticmethod
+    def get_entities_json_schema(
+        component_types: list[type],
+    ) -> str:
+        _, EntitiesTable = Serializer._get_entities_types(component_types)
+        schema = EntitiesTable.model_json_schema()
+        return json.dumps(schema, indent=2)
 
     @staticmethod
     def serialize(

--- a/flanker-core/src/flanker_core/serializer.py
+++ b/flanker-core/src/flanker_core/serializer.py
@@ -1,8 +1,9 @@
+import inspect
 import json
 from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, create_model
+from pydantic import BaseModel, Field, create_model
 
 
 class Serializer:
@@ -19,14 +20,20 @@ class Serializer:
     ) -> tuple[type[BaseModel], type[EntitiesTable[BaseModel]]]:
         """Build BaseModels of Entity and EntitiesTable using component types."""
 
-        component_fields: dict[str, Any] = {
-            t.__name__: (Optional[t], None) for t in component_types
-        }
+        component_fields: dict[str, Any] = {}
+
+        for t in component_types:
+            # Define the field with its type, default value, and description
+            component_fields[t.__name__] = (
+                Optional[t],
+                Field(default=None, description=inspect.getdoc(t)),
+            )
         # TODO: this create_model is security risk by executing arbitrary code
         # see https://docs.pydantic.dev/latest/examples/dynamic_models/
         Entity = create_model("Entity", **component_fields)
         EntitiesTable = create_model(
-            "EntitiesTable", __base__=Serializer.EntitiesTable[Entity]
+            "EntitiesTable",
+            __base__=Serializer.EntitiesTable[Entity],
         )
         return Entity, EntitiesTable
 

--- a/flanker-core/src/flanker_core/serializer.py
+++ b/flanker-core/src/flanker_core/serializer.py
@@ -7,27 +7,27 @@ from pydantic import BaseModel, create_model
 class Serializer:
     """Static class for game state's entity-components serialization."""
 
-    class JsonSchema[TEntity](BaseModel):
-        """Defines the output JSON data structure for serialization"""
+    class EntitiesTable[TEntity](BaseModel):
+        """Defines the entities table data structure."""
 
         entities: dict[UUID, TEntity]
 
     @staticmethod
-    def _build_json_schema(
+    def _get_entities_types(
         component_types: list[type],
-    ) -> tuple[type[BaseModel], type[JsonSchema[BaseModel]]]:
-        """Build Entity and JSON schema using component types."""
+    ) -> tuple[type[BaseModel], type[EntitiesTable[BaseModel]]]:
+        """Build BaseModels of Entity and EntitiesTable using component types."""
 
         component_fields: dict[str, Any] = {
             t.__name__: (Optional[t], None) for t in component_types
         }
         # TODO: this create_model is security risk by executing arbitrary code
         # see https://docs.pydantic.dev/latest/examples/dynamic_models/
-        Entity = create_model("EntityComponent", **component_fields)
-        JsonSchemaType = create_model(
-            "FileData", __base__=Serializer.JsonSchema[Entity]
+        Entity = create_model("Entity", **component_fields)
+        EntitiesTable = create_model(
+            "EntitiesTable", __base__=Serializer.EntitiesTable[Entity]
         )
-        return Entity, JsonSchemaType
+        return Entity, EntitiesTable
 
     @staticmethod
     def serialize(
@@ -36,13 +36,13 @@ class Serializer:
     ) -> str:
         """Serialises entity-component table & id counter to json string"""
 
-        # Define file schema models using existing components
-        Entity, JsonSchema = Serializer._build_json_schema(component_types)
+        # Create pydantic models using component types
+        Entity, EntitiesTable = Serializer._get_entities_types(component_types)
 
-        # Convert entities to using EntityComponent models
-        file_data = JsonSchema(
+        # Convert entities to pydantic models
+        file_data = EntitiesTable(
             entities={
-                # Each entity is validated using built schema
+                # Each entity is validated using the built BaseModel
                 entity_id: Entity(
                     **{
                         comp.__class__.__name__: comp
@@ -65,8 +65,8 @@ class Serializer:
         """Deerialises entity-component table & id counter from json string"""
 
         # Serialize with nulls excluded
-        Entity, FileData = Serializer._build_json_schema(component_types)
-        file_data = FileData.model_validate_json(json_data)
+        Entity, EntitiesTable = Serializer._get_entities_types(component_types)
+        file_data = EntitiesTable.model_validate_json(json_data)
 
         # Convert EntityComponent models to dict[type, Any] components
         entities: dict[UUID, dict[type, Any]] = {

--- a/scripts/generate_scene_schema.py
+++ b/scripts/generate_scene_schema.py
@@ -1,0 +1,25 @@
+from dataclasses import is_dataclass
+from inspect import isclass
+from typing import Any
+
+from flanker_ai.components import AiConfigComponent
+from flanker_core.models import components
+from flanker_core.serializer import Serializer
+
+
+def get_component_types() -> list[type[Any]]:
+
+    # How can I reference TerrainTypeTag?
+    component_types: list[type[Any]] = []
+    component_types.append(AiConfigComponent)
+    for _, cls in vars(components).items():
+        if isclass(cls) and is_dataclass(cls):
+            component_types.append(cls)
+    return component_types
+
+
+if __name__ == "__main__":
+    component_types = get_component_types()
+    schema = Serializer.get_entities_json_schema(component_types)
+    with open("./scripts/scene-schema.json", "w") as f:
+        f.write(schema)

--- a/scripts/scene-schema.json
+++ b/scripts/scene-schema.json
@@ -1,0 +1,579 @@
+{
+  "$defs": {
+    "AiConfigComponent": {
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SearchPolicyConfig"
+            },
+            {
+              "$ref": "#/$defs/HeuristicPolicyConfig"
+            }
+          ],
+          "title": "Config"
+        },
+        "faction": {
+          "$ref": "#/$defs/Faction"
+        }
+      },
+      "required": [
+        "config",
+        "faction"
+      ],
+      "title": "AiConfigComponent",
+      "type": "object"
+    },
+    "AssaultControls": {
+      "properties": {
+        "override": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AssaultOutcomes"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "AssaultControls",
+      "type": "object"
+    },
+    "AssaultOutcomes": {
+      "description": "Defines an assault outcome as fail or success.",
+      "enum": [
+        "FAIL",
+        "SUCCESS"
+      ],
+      "title": "AssaultOutcomes",
+      "type": "string"
+    },
+    "CombatUnit": {
+      "properties": {
+        "faction": {
+          "$ref": "#/$defs/Faction"
+        },
+        "command_id": {
+          "anyOf": [
+            {
+              "format": "uuid",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Command Id"
+        },
+        "status": {
+          "$ref": "#/$defs/Status",
+          "default": "ACTIVE"
+        }
+      },
+      "required": [
+        "faction"
+      ],
+      "title": "CombatUnit",
+      "type": "object"
+    },
+    "EliminationObjective": {
+      "properties": {
+        "target_faction": {
+          "$ref": "#/$defs/Faction"
+        },
+        "winning_faction": {
+          "$ref": "#/$defs/Faction"
+        },
+        "units_to_destroy": {
+          "title": "Units To Destroy",
+          "type": "integer"
+        },
+        "units_destroyed_counter": {
+          "title": "Units Destroyed Counter",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "target_faction",
+        "winning_faction",
+        "units_to_destroy",
+        "units_destroyed_counter"
+      ],
+      "title": "EliminationObjective",
+      "type": "object"
+    },
+    "Entity": {
+      "properties": {
+        "AiConfigComponent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AiConfigComponent"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "Vec2": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Vec2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "Transform": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Transform"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "InitiativeState": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InitiativeState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "CombatUnit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CombatUnit"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "MoveControls": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MoveControls"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "FireControls": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FireControls"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "AssaultControls": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AssaultControls"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "TerrainFeature": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TerrainFeature"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "EliminationObjective": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EliminationObjective"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "Entity",
+      "type": "object"
+    },
+    "ExpansionConfig": {
+      "properties": {
+        "type": {
+          "anyOf": [
+            {
+              "const": "LineBased",
+              "type": "string"
+            },
+            {
+              "const": "Polygonal",
+              "type": "string"
+            }
+          ],
+          "title": "Type"
+        },
+        "iterations": {
+          "title": "Iterations",
+          "type": "integer"
+        },
+        "prune_iterations": {
+          "title": "Prune Iterations",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "type",
+        "iterations",
+        "prune_iterations"
+      ],
+      "title": "ExpansionConfig",
+      "type": "object"
+    },
+    "Faction": {
+      "enum": [
+        "BLUE",
+        "RED"
+      ],
+      "title": "Faction",
+      "type": "string"
+    },
+    "FireControls": {
+      "properties": {
+        "override": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FireOutcomes"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "can_reactive_fire": {
+          "default": true,
+          "title": "Can Reactive Fire",
+          "type": "boolean"
+        }
+      },
+      "title": "FireControls",
+      "type": "object"
+    },
+    "FireOutcomes": {
+      "description": "Defines all fire outcomes.",
+      "enum": [
+        "MISS",
+        "PIN",
+        "SUPPRESS",
+        "KILL"
+      ],
+      "title": "FireOutcomes",
+      "type": "string"
+    },
+    "GridConfig": {
+      "properties": {
+        "type": {
+          "const": "WaypointsCoordinatesGridConfig",
+          "title": "Type",
+          "type": "string"
+        },
+        "spacing": {
+          "title": "Spacing",
+          "type": "number"
+        },
+        "offset": {
+          "title": "Offset",
+          "type": "number"
+        }
+      },
+      "required": [
+        "type",
+        "spacing",
+        "offset"
+      ],
+      "title": "GridConfig",
+      "type": "object"
+    },
+    "HandDrawnConfig": {
+      "properties": {
+        "type": {
+          "const": "WaypointsCoordinatesHandDrawnConfig",
+          "title": "Type",
+          "type": "string"
+        },
+        "waypoint_coordinates": {
+          "items": {
+            "$ref": "#/$defs/Vec2"
+          },
+          "title": "Waypoint Coordinates",
+          "type": "array"
+        }
+      },
+      "required": [
+        "type",
+        "waypoint_coordinates"
+      ],
+      "title": "HandDrawnConfig",
+      "type": "object"
+    },
+    "HeuristicPolicyConfig": {
+      "properties": {
+        "policy_type": {
+          "const": "RandomHeuristic",
+          "title": "Policy Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "policy_type"
+      ],
+      "title": "HeuristicPolicyConfig",
+      "type": "object"
+    },
+    "InitiativeState": {
+      "properties": {
+        "faction": {
+          "$ref": "#/$defs/Faction",
+          "default": "BLUE"
+        }
+      },
+      "title": "InitiativeState",
+      "type": "object"
+    },
+    "MoveControls": {
+      "properties": {
+        "move_type": {
+          "$ref": "#/$defs/MoveType",
+          "default": "FOOT"
+        }
+      },
+      "title": "MoveControls",
+      "type": "object"
+    },
+    "MoveType": {
+      "enum": [
+        "FOOT"
+      ],
+      "title": "MoveType",
+      "type": "string"
+    },
+    "SearchPolicyConfig": {
+      "properties": {
+        "policy_type": {
+          "anyOf": [
+            {
+              "const": "Minimax",
+              "type": "string"
+            },
+            {
+              "const": "Expectimax",
+              "type": "string"
+            }
+          ],
+          "title": "Policy Type"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WaypointsStateConfig"
+            },
+            {
+              "$ref": "#/$defs/UnabstractedStateConfig"
+            }
+          ],
+          "title": "State"
+        }
+      },
+      "required": [
+        "policy_type",
+        "state"
+      ],
+      "title": "SearchPolicyConfig",
+      "type": "object"
+    },
+    "Status": {
+      "enum": [
+        "ACTIVE",
+        "PINNED",
+        "SUPPRESSED"
+      ],
+      "title": "Status",
+      "type": "string"
+    },
+    "TerrainFeature": {
+      "properties": {
+        "vertices": {
+          "items": {
+            "$ref": "#/$defs/Vec2"
+          },
+          "title": "Vertices",
+          "type": "array"
+        },
+        "is_closed_loop": {
+          "default": true,
+          "title": "Is Closed Loop",
+          "type": "boolean"
+        },
+        "flag": {
+          "default": -1,
+          "title": "Flag",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "vertices"
+      ],
+      "title": "TerrainFeature",
+      "type": "object"
+    },
+    "Transform": {
+      "properties": {
+        "position": {
+          "$ref": "#/$defs/Vec2"
+        },
+        "degrees": {
+          "default": 0,
+          "title": "Degrees",
+          "type": "number"
+        }
+      },
+      "required": [
+        "position"
+      ],
+      "title": "Transform",
+      "type": "object"
+    },
+    "UnabstractedStateConfig": {
+      "properties": {
+        "type": {
+          "const": "UnabstractedStateConfig",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "UnabstractedStateConfig",
+      "type": "object"
+    },
+    "Vec2": {
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "title": "Vec2",
+      "type": "object"
+    },
+    "VoronoiConfig": {
+      "properties": {
+        "type": {
+          "const": "WaypointsCoordinatesVoronoiConfig",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "VoronoiConfig",
+      "type": "object"
+    },
+    "WaypointsStateConfig": {
+      "properties": {
+        "type": {
+          "const": "WaypointsStateConfig",
+          "title": "Type",
+          "type": "string"
+        },
+        "points": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridConfig"
+            },
+            {
+              "$ref": "#/$defs/HandDrawnConfig"
+            },
+            {
+              "$ref": "#/$defs/VoronoiConfig"
+            }
+          ],
+          "title": "Points"
+        },
+        "expansion": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ExpansionConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path_tolerance": {
+          "title": "Path Tolerance",
+          "type": "number"
+        }
+      },
+      "required": [
+        "type",
+        "points",
+        "expansion",
+        "path_tolerance"
+      ],
+      "title": "WaypointsStateConfig",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "entities": {
+      "additionalProperties": {
+        "$ref": "#/$defs/Entity"
+      },
+      "propertyNames": {
+        "format": "uuid"
+      },
+      "title": "Entities",
+      "type": "object"
+    }
+  },
+  "required": [
+    "entities"
+  ],
+  "title": "EntitiesTable",
+  "type": "object"
+}

--- a/scripts/scene-schema.json
+++ b/scripts/scene-schema.json
@@ -116,7 +116,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "AiConfigComponent(config: flanker_ai.config_models.SearchPolicyConfig | flanker_ai.config_models.HeuristicPolicyConfig, faction: flanker_core.models.components.InitiativeState.Faction)"
         },
         "Vec2": {
           "anyOf": [
@@ -127,7 +128,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "2D vector class for basic vector operations"
         },
         "Transform": {
           "anyOf": [
@@ -138,7 +140,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Holds spatial data for 2D entities. Used by rendering, movement,\ncombat mechanics, etc. The existence of this component implies\nthat the entity can be visualized in 2D space."
         },
         "InitiativeState": {
           "anyOf": [
@@ -149,7 +152,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Singleton component that keeps track of faction & initiatives."
         },
         "CombatUnit": {
           "anyOf": [
@@ -160,7 +164,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Marks an entity as a direct combat-capable unit.\nTracks unit suppression and command hierarchy tree."
         },
         "MoveControls": {
           "anyOf": [
@@ -171,7 +176,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Marks entity as movable, along with its. Used by move action to\ndetermine which terrain can or cannot cross."
         },
         "FireControls": {
           "anyOf": [
@@ -182,7 +188,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Marks an entity as capable for fire action.\nDefines the set of outcomes and override."
         },
         "AssaultControls": {
           "anyOf": [
@@ -193,7 +200,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Marks an entity as capable for assault action.\nDefines the RNG roll multiplier."
         },
         "TerrainFeature": {
           "anyOf": [
@@ -204,7 +212,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Represents a polygonal terrain feature with terrain type bit flags.\nBit flags are used to determine LOS, movement, and fire types."
         },
         "EliminationObjective": {
           "anyOf": [
@@ -215,7 +224,8 @@
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "description": "Represents the enemy elimination objective for a given faction."
         }
       },
       "title": "Entity",


### PR DESCRIPTION
# Changes
- #201 
  - Added JSON schema mechanism to Serializer
  - Added a script to save json schema of Core and AI component
  - webapi models are not being included. I think this is the archetypes and layering problems outside the scope of this task.
    - Might have to be addressed in #209
  - The json schema could be used in vscode with this settings
    ```json
    "json.schemas": [
        {
          "fileMatch": ["scenes/*.json"],
          "url": "./scripts/scene-schema.json"
        }
      ]
    ```