### PR TITLE
Add Component-Based Selective Copy

### DIFF
--- a/flanker-ai/src/flanker_ai/states/common/ai_branching_service.py
+++ b/flanker-ai/src/flanker_ai/states/common/ai_branching_service.py
@@ -85,7 +85,7 @@ class AiBranchingService:
     def copy(gs: GameState) -> GameState:
         """Selectively copy the game state for mutating entities."""
 
-        return gs.component_selective_copy(
+        return gs.selective_copy(
             # Copy the combat units
             Transform,
             CombatUnit,
@@ -95,7 +95,7 @@ class AiBranchingService:
             InitiativeState,
             EliminationObjective,
             copy_method=replace,
-        ).component_selective_copy(
+        ).selective_copy(
             # AI stall count component has a mutable dict
             AiStallCountComponent,
             copy_method=deepcopy,

--- a/flanker-ai/src/flanker_ai/states/common/ai_branching_service.py
+++ b/flanker-ai/src/flanker_ai/states/common/ai_branching_service.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+from dataclasses import replace
 from itertools import product
 from math import prod
 from typing import Any, Literal
@@ -83,16 +85,21 @@ class AiBranchingService:
     def copy(gs: GameState) -> GameState:
         """Selectively copy the game state for mutating entities."""
 
-        entities_to_copy: set[UUID] = set()
-        for id, _ in gs.query(InitiativeState):
-            entities_to_copy.add(id)
-        for id, _ in gs.query(EliminationObjective):
-            entities_to_copy.add(id)
-        for id, _ in gs.query(CombatUnit):
-            entities_to_copy.add(id)
-        for id, _ in gs.query(AiStallCountComponent):
-            entities_to_copy.add(id)
-        return gs.selective_copy(list(entities_to_copy))
+        return gs.component_selective_copy(
+            # Copy the combat units
+            Transform,
+            CombatUnit,
+            FireControls,
+            AssaultControls,
+            # Copy the singletons
+            InitiativeState,
+            EliminationObjective,
+            copy_method=replace,
+        ).component_selective_copy(
+            # AI stall count component has a mutable dict
+            AiStallCountComponent,
+            copy_method=deepcopy,
+        )
 
     @staticmethod
     def get_reactive_fire_branches(

--- a/flanker-ai/tests/test_branch_merging.py
+++ b/flanker-ai/tests/test_branch_merging.py
@@ -93,6 +93,30 @@ def fixture() -> Fixture:
     )
 
 
+def test_copy(fixture: Fixture) -> None:
+    new_gs = AiBranchingService.copy(fixture.gs)
+
+    # Check that combat units are copied
+    for unit_id, unit, transform, fire_controls in new_gs.query(
+        CombatUnit, Transform, FireControls
+    ):
+        old_unit = fixture.gs.get_component(unit_id, CombatUnit)
+        old_transform = fixture.gs.get_component(unit_id, Transform)
+        old_fire_controls = fixture.gs.get_component(unit_id, FireControls)
+
+        assert id(old_unit) != id(unit)
+        assert id(old_transform) != id(transform)
+        assert id(old_fire_controls) != id(fire_controls)
+
+    # Check that terrains are not copied
+    for terrain_id, transform, terrain in new_gs.query(Transform, TerrainFeature):
+        old_transform = fixture.gs.get_component(terrain_id, Transform)
+        old_terrain = fixture.gs.get_component(terrain_id, TerrainFeature)
+
+        assert id(old_transform) != id(transform)
+        assert id(old_terrain) == id(terrain)
+
+
 def test_one_interrupt(fixture: Fixture) -> None:
 
     move_system = fixture.gs.get(MoveSystem)

--- a/flanker-core/src/flanker_core/gamestate.py
+++ b/flanker-core/src/flanker_core/gamestate.py
@@ -9,8 +9,7 @@ class GameState:
     def __init__(self) -> None:
         """Initializes the game state with empty entities."""
         self._entities: dict[UUID, dict[type[Any], Any]] = {}
-        self._cache: dict[tuple[type, ...], list[tuple[UUID, Any]]] = {}
-        self._ent_id_cache: dict[tuple[type, ...], UUID] = {}
+        self._cache: dict[tuple[type, ...], list[UUID]] = {}
         self._systems: dict[type, type] = {}
 
     def register(self, cls: type[Any]) -> None:
@@ -77,15 +76,24 @@ class GameState:
         """Yields entities and their component instances by given component types."""
         component_types = tuple(filter(None, (t, u, v)))
         if component_types in self._cache:
-            return self._cache[component_types]
+            result: list[tuple[Any, ...]] = []
+            for entity_id in self._cache[component_types]:
+                component_instances: list[Any] = []
+                for component_type in component_types:
+                    entity = self._entities[entity_id]
+                    component_instances.append(entity[component_type])
+                result.append((entity_id, *component_instances))
+            return result
         else:
             result: list[tuple[Any, ...]] = []
+            entity_ids: list[UUID] = []
             for entity_id, components in self._entities.items():
                 if all(ct in components for ct in component_types):
+                    entity_ids.append(entity_id)
                     result.append(
                         (entity_id, *(components[ct] for ct in component_types))
                     )
-            self._cache[component_types] = result
+            self._cache[component_types] = entity_ids
             return result
 
     def dump(self) -> dict[UUID, dict[type, Any]]:
@@ -131,7 +139,7 @@ class GameState:
         new_gs = GameState()
         new_gs._entities = self._entities.copy()
         # new_gs._cache = self._cache.copy()
-        new_gs._cache = {}
+        new_gs._cache = self._cache.copy()
         new_gs._systems = self._systems.copy()
 
         # Copies each entity dict and its component instances

--- a/flanker-core/src/flanker_core/gamestate.py
+++ b/flanker-core/src/flanker_core/gamestate.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, overload
+from typing import Any, Callable, overload
 from uuid import UUID, uuid4
 
 
@@ -10,6 +10,7 @@ class GameState:
         """Initializes the game state with empty entities."""
         self._entities: dict[UUID, dict[type[Any], Any]] = {}
         self._cache: dict[tuple[type, ...], list[tuple[UUID, Any]]] = {}
+        self._ent_id_cache: dict[tuple[type, ...], UUID] = {}
         self._systems: dict[type, type] = {}
 
     def register(self, cls: type[Any]) -> None:
@@ -73,7 +74,7 @@ class GameState:
     def query(
         self, t: type, u: type | None = None, v: type | None = None
     ) -> list[tuple[Any, ...]]:
-        """Yields all entities with a specific component type."""
+        """Yields entities and their component instances by given component types."""
         component_types = tuple(filter(None, (t, u, v)))
         if component_types in self._cache:
             return self._cache[component_types]
@@ -98,8 +99,9 @@ class GameState:
         gs._entities = deepcopy(entities)
         return gs
 
+    # TODO: deprecate this
     def selective_copy(self, entity_ids: list[UUID]) -> "GameState":
-        """Deep copies the selected entities."""
+        """Deep copies the selected components."""
         new_gs = GameState()
         # Shallow copy everything by default
         new_gs._entities = dict(self._entities)
@@ -116,5 +118,40 @@ class GameState:
                 for cache_key in list(new_gs._cache.keys()):
                     if component_type in cache_key:
                         new_gs._cache.pop(cache_key)
+
+        return new_gs
+
+    def component_selective_copy(
+        self,
+        *component_types: type[Any],
+        copy_method: Callable[[Any], Any],
+    ) -> "GameState":
+
+        # Shallow copy everything by default
+        new_gs = GameState()
+        new_gs._entities = self._entities.copy()
+        # new_gs._cache = self._cache.copy()
+        new_gs._cache = {}
+        new_gs._systems = self._systems.copy()
+
+        # Copies each entity dict and its component instances
+        for entity_id in new_gs._entities:
+            new_entity = new_gs._entities[entity_id].copy()
+            new_gs._entities[entity_id] = new_entity
+
+            # Copy its components based using specified method
+            for component_type in new_entity:
+                if component_type not in component_types:
+                    continue
+                new_component = copy_method(new_entity[component_type])
+                new_entity[component_type] = new_component
+
+        # IDEA
+        # What about making the cache store the entity ID instead?
+        # This makes entity table be the SSOT and cache simply points there
+        # Avoids linear search just fine with a few extra dict lookup.
+        # It makes cache clearing easier for selective copy.
+        # for cache_key, cache in new_gs._cache.items():
+        #     ...
 
         return new_gs

--- a/flanker-core/src/flanker_core/gamestate.py
+++ b/flanker-core/src/flanker_core/gamestate.py
@@ -122,7 +122,7 @@ class GameState:
         *component_types: type[Any],
         copy_method: Callable[[Any], Any],
     ) -> "GameState":
-        """Deep copies the selected components."""
+        """Copies the selected components using specified copy method."""
 
         # Shallow copy everything by default
         new_gs = GameState()

--- a/flanker-core/src/flanker_core/gamestate.py
+++ b/flanker-core/src/flanker_core/gamestate.py
@@ -135,7 +135,7 @@ class GameState:
             new_entity = new_gs._entities[entity_id].copy()
             new_gs._entities[entity_id] = new_entity
 
-            # Copy its components based using specified method
+            # Copy its components instances using specified method
             for component_type in new_entity:
                 if component_type not in component_types:
                     continue

--- a/flanker-core/src/flanker_core/gamestate.py
+++ b/flanker-core/src/flanker_core/gamestate.py
@@ -60,41 +60,51 @@ class GameState:
         return self._entities.get(entity_id, {}).get(component_type, None)
 
     @overload
-    def query[T](self, t: type[T]) -> list[tuple[UUID, T]]: ...
+    def query[T](
+        self,
+        t: type[T],
+    ) -> list[tuple[UUID, T]]: ...
 
     @overload
-    def query[T, U](self, t: type[T], u: type[U]) -> list[tuple[UUID, T, U]]: ...
+    def query[T, U](
+        self,
+        t: type[T],
+        u: type[U],
+    ) -> list[tuple[UUID, T, U]]: ...
 
     @overload
     def query[T, U, V](
-        self, t: type[T], u: type[U], v: type[V]
+        self,
+        t: type[T],
+        u: type[U],
+        v: type[V],
     ) -> list[tuple[UUID, T, U, V]]: ...
 
     def query(
-        self, t: type, u: type | None = None, v: type | None = None
+        self,
+        t: type,
+        u: type | None = None,
+        v: type | None = None,
     ) -> list[tuple[Any, ...]]:
-        """Yields entities and their component instances by given component types."""
+        """Yields entities and their components by given component types."""
         component_types = tuple(filter(None, (t, u, v)))
-        if component_types in self._cache:
-            result: list[tuple[Any, ...]] = []
-            for entity_id in self._cache[component_types]:
-                component_instances: list[Any] = []
-                for component_type in component_types:
-                    entity = self._entities[entity_id]
-                    component_instances.append(entity[component_type])
-                result.append((entity_id, *component_instances))
-            return result
-        else:
-            result: list[tuple[Any, ...]] = []
-            entity_ids: list[UUID] = []
-            for entity_id, components in self._entities.items():
-                if all(ct in components for ct in component_types):
-                    entity_ids.append(entity_id)
-                    result.append(
-                        (entity_id, *(components[ct] for ct in component_types))
-                    )
+
+        # If cache miss, linear search entities with matching component types
+        if component_types not in self._cache:
+            entity_ids: list[UUID] = [
+                entity_id
+                for entity_id, components in self._entities.items()
+                if all(ct in components for ct in component_types)
+            ]
             self._cache[component_types] = entity_ids
-            return result
+
+        # The entity IDs are matched; return their components
+        result: list[tuple[Any, ...]] = []
+        for entity_id in self._cache[component_types]:
+            entity = self._entities[entity_id]
+            components: list[Any] = [entity[ct] for ct in component_types]
+            result.append((entity_id, *components))
+        return result
 
     def dump(self) -> dict[UUID, dict[type, Any]]:
         """Returns a deep copy of the entities table."""

--- a/flanker-core/src/flanker_core/gamestate.py
+++ b/flanker-core/src/flanker_core/gamestate.py
@@ -9,7 +9,7 @@ class GameState:
     def __init__(self) -> None:
         """Initializes the game state with empty entities."""
         self._entities: dict[UUID, dict[type[Any], Any]] = {}
-        self._cache: dict[tuple[type, ...], list[UUID]] = {}
+        self._query_cache: dict[tuple[type, ...], list[UUID]] = {}
         self._systems: dict[type, type] = {}
 
     def register(self, cls: type[Any]) -> None:
@@ -40,13 +40,13 @@ class GameState:
             raise ValueError(f"entity {id=} already exists")
         new_id = uuid4() if id is None else id
         self._entities[new_id] = {type(c): c for c in components}
-        self._cache = {}
+        self._query_cache = {}
         return new_id
 
     def delete_entity(self, entity_id: UUID) -> None:
         """Deletes an entity by its ID"""
         self._entities.pop(entity_id)
-        self._cache = {}
+        self._query_cache = {}
 
     def get_component[T](self, entity_id: UUID, component_type: type[T]) -> T:
         """Get an entity's component. None if entity or component not found."""
@@ -90,17 +90,17 @@ class GameState:
         component_types = tuple(filter(None, (t, u, v)))
 
         # If cache miss, linear search entities with matching component types
-        if component_types not in self._cache:
+        if component_types not in self._query_cache:
             entity_ids: list[UUID] = [
                 entity_id
                 for entity_id, components in self._entities.items()
                 if all(ct in components for ct in component_types)
             ]
-            self._cache[component_types] = entity_ids
+            self._query_cache[component_types] = entity_ids
 
         # The entity IDs are matched; return their components
         result: list[tuple[Any, ...]] = []
-        for entity_id in self._cache[component_types]:
+        for entity_id in self._query_cache[component_types]:
             entity = self._entities[entity_id]
             components: list[Any] = [entity[ct] for ct in component_types]
             result.append((entity_id, *components))
@@ -117,39 +117,17 @@ class GameState:
         gs._entities = deepcopy(entities)
         return gs
 
-    # TODO: deprecate this
-    def selective_copy(self, entity_ids: list[UUID]) -> "GameState":
-        """Deep copies the selected components."""
-        new_gs = GameState()
-        # Shallow copy everything by default
-        new_gs._entities = dict(self._entities)
-        new_gs._cache = dict(self._cache)
-        new_gs._systems = dict(self._systems)
-        # Deep copy the selected entities.
-        for id in entity_ids:
-            if id not in new_gs._entities:
-                raise KeyError(f"entity {id=} does not exist.")
-            new_gs._entities[id] = deepcopy(self._entities[id])
-            # Clear cache for selected entities.
-            components = list(new_gs._entities[id].keys())
-            for component_type in components:
-                for cache_key in list(new_gs._cache.keys()):
-                    if component_type in cache_key:
-                        new_gs._cache.pop(cache_key)
-
-        return new_gs
-
-    def component_selective_copy(
+    def selective_copy(
         self,
         *component_types: type[Any],
         copy_method: Callable[[Any], Any],
     ) -> "GameState":
+        """Deep copies the selected components."""
 
         # Shallow copy everything by default
         new_gs = GameState()
         new_gs._entities = self._entities.copy()
-        # new_gs._cache = self._cache.copy()
-        new_gs._cache = self._cache.copy()
+        new_gs._query_cache = self._query_cache.copy()
         new_gs._systems = self._systems.copy()
 
         # Copies each entity dict and its component instances
@@ -163,13 +141,5 @@ class GameState:
                     continue
                 new_component = copy_method(new_entity[component_type])
                 new_entity[component_type] = new_component
-
-        # IDEA
-        # What about making the cache store the entity ID instead?
-        # This makes entity table be the SSOT and cache simply points there
-        # Avoids linear search just fine with a few extra dict lookup.
-        # It makes cache clearing easier for selective copy.
-        # for cache_key, cache in new_gs._cache.items():
-        #     ...
 
         return new_gs

--- a/scripts/ai_perf_test.py
+++ b/scripts/ai_perf_test.py
@@ -1,9 +1,11 @@
+import random
 from dataclasses import is_dataclass
 from inspect import isclass
 from typing import Any
 
+from flanker_ai.ai_agent import AiAgent
 from flanker_ai.ai_trial import AiTrial
-from flanker_ai.components import AiConfigComponent
+from flanker_ai.components import AiConfigComponent, InitiativeState
 from flanker_core.gamestate import GameState
 from flanker_core.models import components
 from flanker_core.serializer import Serializer
@@ -32,6 +34,13 @@ def load_state(path: str) -> GameState:
 if __name__ == "__main__":
     PATH = "./scenes/experiment-s2.json"
     gs = load_state(PATH)
+
+    # Ensures that each run is consistent in search size
+    random.seed(10)
+
+    # Initialize the state first
+    _ = AiAgent.get_agent(gs, InitiativeState.Faction.BLUE)
+    _ = AiAgent.get_agent(gs, InitiativeState.Faction.RED)
 
     def run_ai_trial() -> None:
         result = AiTrial.run_trial(gs)


### PR DESCRIPTION
# Changes
- #212 
  - Added a smarter selective copy using component types
  - The caller provides the specific copying mechanism for specific component types. 
  - This allows for a better-suited copying method. Most components are shallow copied with `replace`. Only `AiStallCountComponent` is deep copied due to its dictionary field.
  - Also refactored game state query cache. This new cache only stores the entity ID. Thus, the entity-components are centralized into a single canonical SSOT dictionary. 
    - Very minor performance speed up by having selective copy not clearing cache
    - I think the second benefit is more for having a safe SSOT for entity-components 