### PR TITLE
Optimized Unabstracted State for AI

### DIFF
--- a/flanker-ai/src/flanker_ai/policies/minimax_policy.py
+++ b/flanker-ai/src/flanker_ai/policies/minimax_policy.py
@@ -31,7 +31,7 @@ class MinimaxPolicy[TAction](IPolicy[TAction]):
     ) -> tuple[float, TAction | None]:
 
         global count
-        if count % 50000 == 0:
+        if count % 5000 == 0:
             print(count)
         count += 1
 

--- a/flanker-core/src/flanker_core/systems/los_system.py
+++ b/flanker-core/src/flanker_core/systems/los_system.py
@@ -159,12 +159,16 @@ class LosSystem:
             line=(line[0], line[1]),
             polyline=fov_polygon,
         ):
+            earliest_point = min(
+                intersects,
+                key=lambda point: (line[0] - point).length(),
+            )
             # Add a tiny offset to prevent coordinate from sitting
             # precisely on LOS polygon edge.
             # This reduces floating point sensitivity.
             line_direction = line[1] - line[0]
             offset = line_direction * 1e-12
-            interrupt_pos = intersects[0] + offset
+            interrupt_pos = earliest_point + offset
 
         return interrupt_pos
 
@@ -185,12 +189,20 @@ class LosSystem:
         half_angle_rad = math.radians(fov_degree / 2)
         left_ray: Vec2 = center_point + forward_ray.rotated(half_angle_rad)
         right_ray: Vec2 = center_point + forward_ray.rotated(-half_angle_rad)
-        left_point: Vec2 = IntersectGetter.get_intersects(
-            line=(center_point, left_ray), polyline=polyline
-        )[0]
-        right_point: Vec2 = IntersectGetter.get_intersects(
-            line=(center_point, right_ray), polyline=polyline
-        )[0]
+
+        # Choose the two first intersection points of this FOV cone
+        left_point = min(
+            IntersectGetter.get_intersects(
+                line=(center_point, left_ray), polyline=polyline
+            ),
+            key=lambda point: (center_point - point).length(),
+        )
+        right_point = min(
+            IntersectGetter.get_intersects(
+                line=(center_point, right_ray), polyline=polyline
+            ),
+            key=lambda point: (center_point - point).length(),
+        )
 
         # Filter LOS polygon of any points outside of FOV
         threshold_rad: float = math.cos(half_angle_rad)
@@ -255,18 +267,16 @@ class LosSystem:
             left_point = spotter_pos - jitter
             right_point = spotter_pos + jitter
             for point in [left_point, right_point]:
-                intersects = list(
+                intersects = sorted(
                     los_system._get_terrain_intersects(
                         line=(point, point + ray),
                         terrains=terrains,
-                    )
+                    ),
+                    key=lambda i: (i.point - spotter_pos).length(),
                 )
                 # Choose which point from the intersects to append
                 if intersects:
-                    intersects = los_system._sort_intersects_by_distance(
-                        intersects, spotter_pos
-                    )
-                    # Use the second intersection point to allow see-into terrain
+                    # Selects the second point to allow see-into terrain
                     if len(intersects) > 1:
                         new_point = intersects[1].point
                     else:
@@ -342,7 +352,7 @@ class LosSystem:
         line: tuple[Vec2, Vec2],
         terrains: list[_Terrain],
     ) -> Iterable[_TerrainIntersection]:
-        """Yields intersections between the line segment and terrain."""
+        """Yields unsorted intersections between the line segment and terrain."""
         for terrain in terrains:
             points = IntersectGetter.get_intersects(
                 line=line,

--- a/flanker-core/src/flanker_core/systems/los_system.py
+++ b/flanker-core/src/flanker_core/systems/los_system.py
@@ -34,6 +34,7 @@ class _Terrain:
 @dataclass
 class _LosCacheComponent:
     los_polygon_by_point: dict[Vec2, list[Vec2]]
+    fov_polygon_by_point: dict[tuple[Vec2, float], list[Vec2]]
 
 
 class LosSystem:
@@ -121,28 +122,42 @@ class LosSystem:
 
         spotter_transform = gs.get_component(spotter_id, Transform)
 
-        full_polygon = los_system.get_los_polygon(
-            gs=gs,
-            spotter_pos=spotter_transform.position,
+        # If already exists in cache, no need to recalculate
+        if ent := gs.query(_LosCacheComponent):
+            _, cache = ent[0]
+        else:
+            gs.add_entity(cache := _LosCacheComponent({}, {}))
+
+        cache_key: tuple[Vec2, float] = (
+            spotter_transform.position,
+            spotter_transform.degrees,
         )
-        los_polygon = los_system.apply_fov_to_polygon(
-            polyline=full_polygon,
-            center_point=spotter_transform.position,
-            heading_degree=spotter_transform.degrees,
-        )
+        if cache_key in cache.fov_polygon_by_point:
+            fov_polygon = cache.fov_polygon_by_point[cache_key]
+        else:
+            los_polygon = los_system.get_los_polygon(
+                gs=gs,
+                spotter_pos=spotter_transform.position,
+            )
+            fov_polygon = los_system.apply_fov_to_polygon(
+                polyline=los_polygon,
+                center_point=spotter_transform.position,
+                heading_degree=spotter_transform.degrees,
+            )
+            cache.fov_polygon_by_point[cache_key] = fov_polygon
 
         # If the first point is inside, ignore any intersections and
         # return the first point right away.
         if IntersectGetter.is_inside(
             point=line[0],
-            polygon=los_polygon,
+            polygon=fov_polygon,
         ):
             interrupt_pos = line[0]
 
         # The first point is outside, thus only care about intersection
         elif intersects := IntersectGetter.get_intersects(
             line=(line[0], line[1]),
-            polyline=los_polygon,
+            polyline=fov_polygon,
         ):
             # Add a tiny offset to prevent coordinate from sitting
             # precisely on LOS polygon edge.
@@ -217,7 +232,7 @@ class LosSystem:
         if ent := gs.query(_LosCacheComponent):
             _, cache = ent[0]
         else:
-            gs.add_entity(cache := _LosCacheComponent({}))
+            gs.add_entity(cache := _LosCacheComponent({}, {}))
         if spotter_pos in cache.los_polygon_by_point:
             return cache.los_polygon_by_point[spotter_pos]
 

--- a/flanker-core/src/flanker_core/systems/los_system.py
+++ b/flanker-core/src/flanker_core/systems/los_system.py
@@ -31,6 +31,11 @@ class _Terrain:
     vertices: list[Vec2]
 
 
+@dataclass
+class _LosCacheComponent:
+    los_polygon_by_point: dict[Vec2, list[Vec2]]
+
+
 class LosSystem:
     """Static system class for checking Line-of-Sight (LOS) against terrain."""
 
@@ -207,6 +212,15 @@ class LosSystem:
     ) -> list[Vec2]:
         """Returns a polygon representing the LOS from a spotter position."""
         los_system = gs.get(LosSystem)
+
+        # If already exists in cache, no need to recalculate
+        if ent := gs.query(_LosCacheComponent):
+            _, cache = ent[0]
+        else:
+            gs.add_entity(cache := _LosCacheComponent({}))
+        if spotter_pos in cache.los_polygon_by_point:
+            return cache.los_polygon_by_point[spotter_pos]
+
         terrains = list(
             los_system._get_terrain_vertices(
                 gs,
@@ -216,7 +230,7 @@ class LosSystem:
         )
         terrain_verts = [vert for t in terrains for vert in t.vertices]
         verts = los_system._sort_verts_by_angle(spotter_pos, terrain_verts)
-        visible_points: list[Vec2] = []
+        los_polygon: list[Vec2] = []
         for vert in verts:
             direction = (vert - spotter_pos).normalized()
             ray = direction * radius
@@ -250,16 +264,17 @@ class LosSystem:
                 if (new_point - vert).length() < 1e-3:
                     new_point = vert
                 # If points are colocated, don't append
-                if visible_points and visible_points[-1] == new_point:
+                if los_polygon and los_polygon[-1] == new_point:
                     continue
                 # If points are colinear, replace instead of append
-                if los_system._is_colinear(visible_points, new_point):
-                    visible_points[-1] = new_point
+                if los_system._is_colinear(los_polygon, new_point):
+                    los_polygon[-1] = new_point
                     continue
-                visible_points.append(new_point)
+                los_polygon.append(new_point)
 
-        visible_points.append(visible_points[0])
-        return visible_points
+        los_polygon.append(los_polygon[0])
+        cache.los_polygon_by_point[spotter_pos] = los_polygon
+        return los_polygon
 
     @staticmethod
     def _sort_verts_by_angle(

--- a/flanker-core/src/flanker_core/utils/intersect_getter.py
+++ b/flanker-core/src/flanker_core/utils/intersect_getter.py
@@ -37,14 +37,15 @@ class IntersectGetter:
     def get_intersects(
         line: tuple[Vec2, Vec2],
         polyline: list[Vec2],
-    ) -> list[Vec2]:
+    ) -> set[Vec2]:
         """
         Returns intersection points between a line and a polyline.
         For a closed loop, the vertices must repeat `polyline[-1] == polyline[0]`.
+        The intersections are not sorted.
         """
 
         if len(polyline) < 2:
-            return []
+            return set()
 
         # Convert to np arrays and let the compiled function compute
         intersections = IntersectGetter._njit_get_intersect(
@@ -54,9 +55,7 @@ class IntersectGetter:
         )
         # Convert to Vec2
         points = [Vec2(float(x), float(y)) for x, y in intersections]
-        # Filter out colocated intersection points if exists
-        unique_points = [p for i, p in enumerate(points) if p not in points[:i]]
-        return list(unique_points)
+        return set(points)
 
     @staticmethod
     @njit(cache=True)  # type: ignore
@@ -70,6 +69,7 @@ class IntersectGetter:
         Takes line_start, line_end, and polyline (Nx2 array of vertices).
         Computes all line segment intersections between the line and polyline edges.
         Note: might return duplicate points if edges share a vertex.
+        Note: returns an unsorted array of intersect points.
         Returns NDArray (M x 2) of intersection points.
         """
 

--- a/flanker-core/tests/test_move_reactive_fire_fov.py
+++ b/flanker-core/tests/test_move_reactive_fire_fov.py
@@ -40,7 +40,7 @@ def fixture() -> Fixture:
         CombatUnit(faction=InitiativeState.Faction.RED),
         FireControls(override=FireOutcomes.PIN),
         Transform(
-            position=Vec2(20, 10),
+            position=Vec2(-20, 10),
             degrees=-90,
         ),
     )
@@ -69,11 +69,11 @@ def fixture() -> Fixture:
 
 def test_reactive_fire_at_fov(fixture: Fixture) -> None:
     move_system = fixture.gs.get(MoveSystem)
-    move_system.move(fixture.gs, fixture.unit_move, Vec2(20, 0))
+    move_system.move(fixture.gs, fixture.unit_move, Vec2(-50, 0))
     transform = fixture.gs.get_component(fixture.unit_move, Transform)
     assert transform.position == Vec2(
-        10, 0
-    ), "Expects to be interrupted at FOV border (10, 0)."
+        -10, 0
+    ), "Expects to be interrupted at FOV border (-10, 0)."
 
 
 def test_reactive_fire_after_rotated(fixture: Fixture) -> None:

--- a/flanker-core/tests/test_move_reactive_fire_fov.py
+++ b/flanker-core/tests/test_move_reactive_fire_fov.py
@@ -80,9 +80,9 @@ def test_reactive_fire_after_rotated(fixture: Fixture) -> None:
     # Rotate the RED unit slightly to the left so that FOV is 56.31 degrees
     move_system = fixture.gs.get(MoveSystem)
     red_transform = fixture.gs.get_component(fixture.unit_shoot, Transform)
-    red_transform.degrees = -101.31
-    move_system.move(fixture.gs, fixture.unit_move, Vec2(20, 0))
+    red_transform.degrees = -78.69
+    move_system.move(fixture.gs, fixture.unit_move, Vec2(-50, 0))
     transform = fixture.gs.get_component(fixture.unit_move, Transform)
     assert (
-        transform.position - Vec2(5, 0)
-    ).length() < 1e-2, "Expects to be interrupted at FOV border (5, 0)."
+        transform.position - Vec2(-5, 0)
+    ).length() < 1e-2, "Expects to be interrupted at FOV border (-5, 0)."

--- a/scenes/experiment-unabstracted.json
+++ b/scenes/experiment-unabstracted.json
@@ -1,0 +1,265 @@
+{
+  "entities": {
+    "066d81b5-2e25-4175-8ea5-0b1f71f73c1d": {
+      "InitiativeState": {
+        "faction": "BLUE"
+      },
+      "EliminationObjective": {
+        "target_faction": "RED",
+        "winning_faction": "BLUE",
+        "units_to_destroy": 2,
+        "units_destroyed_counter": 0
+      }
+    },
+    "1859782c-bf0d-417c-959f-445375719293": {
+      "EliminationObjective": {
+        "target_faction": "BLUE",
+        "winning_faction": "RED",
+        "units_to_destroy": 2,
+        "units_destroyed_counter": 0
+      }
+    },
+    "b139e1d9-7df9-4148-a8db-137df1c0fa7c": {
+      "Transform": {
+        "position": {
+          "x": 0.0,
+          "y": 0.0
+        },
+        "degrees": 0.0
+      },
+      "TerrainFeature": {
+        "vertices": [
+          {
+            "x": 0.0,
+            "y": 0.0
+          },
+          {
+            "x": 300.0,
+            "y": 0.0
+          },
+          {
+            "x": 300.0,
+            "y": 300.0
+          },
+          {
+            "x": 0.0,
+            "y": 300.0
+          }
+        ],
+        "is_closed_loop": true,
+        "flag": 33
+      }
+    },
+    "843fadf4-9645-44ec-9d42-9ac658e964ca": {
+      "Transform": {
+        "position": {
+          "x": 40.0,
+          "y": 40.0
+        },
+        "degrees": 0.0
+      },
+      "CombatUnit": {
+        "faction": "BLUE",
+        "status": "ACTIVE"
+      },
+      "MoveControls": {
+        "move_type": "FOOT"
+      },
+      "FireControls": {
+        "can_reactive_fire": true
+      },
+      "AssaultControls": {}
+    },
+    "301ab44d-d18b-47d7-8406-add359176995": {
+      "Transform": {
+        "position": {
+          "x": 60.0,
+          "y": 40.0
+        },
+        "degrees": 0.0
+      },
+      "CombatUnit": {
+        "faction": "BLUE",
+        "status": "ACTIVE"
+      },
+      "MoveControls": {
+        "move_type": "FOOT"
+      },
+      "FireControls": {
+        "can_reactive_fire": true
+      },
+      "AssaultControls": {}
+    },
+    "c0be4c67-72fe-4164-9a44-bc153079948a": {
+      "Transform": {
+        "position": {
+          "x": 40.0,
+          "y": 230.0
+        },
+        "degrees": -70.0
+      },
+      "CombatUnit": {
+        "faction": "RED",
+        "status": "ACTIVE"
+      },
+      "MoveControls": {
+        "move_type": "FOOT"
+      },
+      "FireControls": {
+        "can_reactive_fire": true
+      },
+      "AssaultControls": {}
+    },
+    "473a9efb-ff36-4e44-af13-327f60bbd79f": {
+      "Transform": {
+        "position": {
+          "x": 100.0,
+          "y": 240.0
+        },
+        "degrees": -90.0
+      },
+      "CombatUnit": {
+        "faction": "RED",
+        "status": "ACTIVE"
+      },
+      "MoveControls": {
+        "move_type": "FOOT"
+      },
+      "FireControls": {
+        "can_reactive_fire": true
+      },
+      "AssaultControls": {}
+    },
+    "722332cc-99c2-41f0-9b60-96916cb9a726": {
+      "AiConfigComponent": {
+        "faction": "BLUE",
+        "config": {
+          "policy_type": "Minimax",
+          "state": {
+            "type": "UnabstractedStateConfig"
+          }
+        }
+      }
+    },
+    "9d8d492b-f5a7-49a1-a835-4db89614e8a0": {
+      "AiConfigComponent": {
+        "faction": "RED",
+        "config": {
+          "policy_type": "RandomHeuristic"
+        }
+      }
+    },
+    "c08e1c9e-d67c-4bd7-bb00-38c423ecc7cf": {
+      "Transform": {
+        "position": {
+          "x": 86.0,
+          "y": 61.0
+        },
+        "degrees": 0.0
+      },
+      "TerrainFeature": {
+        "vertices": [
+          {
+            "x": 0.0,
+            "y": 0.0
+          },
+          {
+            "x": 48.666666666666686,
+            "y": 8.666666666666657
+          },
+          {
+            "x": 83.33333333333334,
+            "y": 31.33333333333333
+          },
+          {
+            "x": 106.66666666666666,
+            "y": 31.33333333333333
+          },
+          {
+            "x": 117.33333333333334,
+            "y": 17.33333333333333
+          },
+          {
+            "x": 82.66666666666669,
+            "y": -12.000000000000007
+          },
+          {
+            "x": 20.666666666666686,
+            "y": -28.66666666666667
+          },
+          {
+            "x": -3.3333333333333144,
+            "y": -23.333333333333336
+          },
+          {
+            "x": -11.333333333333314,
+            "y": -12.666666666666671
+          }
+        ],
+        "is_closed_loop": true,
+        "flag": 3
+      },
+      "TerrainTypeTag": {
+        "type": "FOREST"
+      }
+    },
+    "b55c0fc4-2537-41aa-b1b6-c9baab251197": {
+      "Transform": {
+        "position": {
+          "x": -0.6081467669706202,
+          "y": 114.0
+        },
+        "degrees": 0.0
+      },
+      "TerrainFeature": {
+        "vertices": [
+          {
+            "x": 0.0,
+            "y": 0.0
+          },
+          {
+            "x": -1.1486983549970344,
+            "y": 50.54272761986951
+          },
+          {
+            "x": 28.33455942326018,
+            "y": 39.43864352156484
+          },
+          {
+            "x": 79.64308594646106,
+            "y": 26.802961616597457
+          },
+          {
+            "x": 116.40143330636616,
+            "y": 24.12266545493773
+          },
+          {
+            "x": 132.48321027632466,
+            "y": 14.167279711630101
+          },
+          {
+            "x": 137.84380259964414,
+            "y": 0.0
+          },
+          {
+            "x": 130.95161246966194,
+            "y": -14.550179163295766
+          },
+          {
+            "x": 102.61705304640174,
+            "y": -20.67657038994662
+          },
+          {
+            "x": 67.00740404149367,
+            "y": -17.6133747766212
+          }
+        ],
+        "is_closed_loop": true,
+        "flag": 3
+      },
+      "TerrainTypeTag": {
+        "type": "FOREST"
+      }
+    }
+  }
+}

--- a/scripts/ai_perf_test.py
+++ b/scripts/ai_perf_test.py
@@ -32,7 +32,7 @@ def load_state(path: str) -> GameState:
 
 
 if __name__ == "__main__":
-    PATH = "./scenes/experiment-s2.json"
+    PATH = "./scenes/experiment-unabstracted.json"
     gs = load_state(PATH)
 
     # Ensures that each run is consistent in search size
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     import cProfile
     import pstats
 
-    cProfile.run("run_ai_trial()", sort="tottime", filename="./scripts/ai-perftest.txt")
+    cProfile.run("run_ai_trial()", sort="cumtime", filename="./scripts/ai-perftest.txt")
     p = pstats.Stats("./scripts/ai-perftest.txt")
-    p.sort_stats("tottime")
+    p.sort_stats("cumtime")
     p.print_stats(20)

--- a/scripts/visualize_scene.py
+++ b/scripts/visualize_scene.py
@@ -202,11 +202,15 @@ if __name__ == "__main__":
 
     gs = load_state("./scenes/experiment-grid.json")
 
-    img = mpimg.imread("./scripts/experiment-s2.png")  # type: ignore
-    plt.imshow(  # type: ignore
-        img,  # type: ignore
-        extent=[0, 300, 300, 0],  # type: ignore
-    )
+    screenshot = "./scripts/experiment-s2.png"
+    if screenshot:
+        img = mpimg.imread(screenshot)  # type: ignore
+        plt.imshow(  # type: ignore
+            img,  # type: ignore
+            extent=[0, 300, 300, 0],  # type: ignore
+        )
+    else:
+        plt.gca().invert_yaxis()
 
     # draw_terrains(gs)
     draw_waypoints(gs, InitiativeState.Faction.BLUE, draw_ids=True)

--- a/scripts/visualize_scene.py
+++ b/scripts/visualize_scene.py
@@ -46,7 +46,7 @@ def visualize_polygon(
     plot_alpha: float = 1,
 ) -> None:
     xs = [v.x for v in verts]
-    ys = [-v.y for v in verts]
+    ys = [v.y for v in verts]
 
     # plt.scatter(xs, ys, color=color)  # type: ignore
     plt.fill(xs, ys, color=color, alpha=fill_alpha)  # type: ignore
@@ -141,26 +141,26 @@ def draw_waypoints(
         if draw_ids:
             plt.text(  # type: ignore
                 point.position.x,
-                -point.position.y,
+                point.position.y,
                 str(id),
             )
 
         if id in accented_ids:
             accented_points_x.append(point.position.x)
-            accented_points_y.append(-point.position.y)
+            accented_points_y.append(point.position.y)
 
             for visible_node_id in point.visible_nodes:
                 visible_node = waypoints[visible_node_id]
 
                 accented_segments.append(
                     [
-                        (point.position.x, -point.position.y),
-                        (visible_node.position.x, -visible_node.position.y),
+                        (point.position.x, point.position.y),
+                        (visible_node.position.x, visible_node.position.y),
                     ]
                 )
             continue
         points_x.append(point.position.x)
-        points_y.append(-point.position.y)
+        points_y.append(point.position.y)
         ids.append(id)
 
         for visible_node_id in point.visible_nodes:
@@ -168,8 +168,8 @@ def draw_waypoints(
 
             segments.append(
                 [
-                    (point.position.x, -point.position.y),
-                    (visible_node.position.x, -visible_node.position.y),
+                    (point.position.x, point.position.y),
+                    (visible_node.position.x, visible_node.position.y),
                 ]
             )
 
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     img = mpimg.imread("./scripts/experiment-s2.png")  # type: ignore
     plt.imshow(  # type: ignore
         img,  # type: ignore
-        extent=[0, 300, -300, 0],  # type: ignore
+        extent=[0, 300, 300, 0],  # type: ignore
     )
 
     # draw_terrains(gs)


### PR DESCRIPTION
# Changes
- #211 
  - Add LOS and FOV core-level cache.
  - This cache assumes that visibility-related entities such as opaque terrains are never mutated. 
  - This assumption isn't the most correct from a game rules perspective, so this might cause bugs later. This could be fixed as a separate issue using hash based cache key. The idea is to hash all the visibility-relevant entities and use that as cache key. If those are mutated, then it would be immediate to consider cache miss.
- #214 
  - This is due to `IntersectGetter` returning unsorted intersects, while other systems not consider that and use indexing.
  - Refactored return type to set to force future cases to know it's unsorted
  - Added min and sorts.
- Cleaned up visualization script y-axis inverting