### PR TITLE
Fix AI Not Peeking

### DIFF
--- a/flanker-ai/src/flanker_ai/config_models.py
+++ b/flanker-ai/src/flanker_ai/config_models.py
@@ -42,7 +42,6 @@ class PointsConfig:
     @dataclass
     class FlagPruneConfig:
         type: Literal["FlagPrune"]
-        flag_size: int
 
     @dataclass
     class WeightsPruneConfig:

--- a/flanker-ai/src/flanker_ai/states/common/ai_points_expansion_service.py
+++ b/flanker-ai/src/flanker_ai/states/common/ai_points_expansion_service.py
@@ -62,13 +62,8 @@ class AiPointsExpansionService:
                 case PointsConfig.PolygonalExpansionConfig():
                     raise NotImplementedError()
                 case PointsConfig.FlagPruneConfig():
-                    flag_waypoints = (
-                        AiPointsExpansionService._prune_waypoints_by_weight(
-                            waypoints=waypoints,
-                            remaining_size=expansion_config.flag_size,
-                        )
-                    )
-                    # Include combat unit positions to help with smarter pruning
+                    # Use combat unit positions as flags
+                    flag_waypoints: list[Vec2] = []
                     if config.use_combat_unit_positions == True:
                         for _, _, transform in gs.query(CombatUnit, Transform):
                             flag_waypoints.append(transform.position)

--- a/flanker-ai/src/flanker_ai/states/common/ai_points_expansion_service.py
+++ b/flanker-ai/src/flanker_ai/states/common/ai_points_expansion_service.py
@@ -223,6 +223,9 @@ class AiPointsExpansionService:
         Removes waypoints with the lowest weight values. The weights
         currently used is the distance to nearest neighbour.
         """
+        if remaining_size == 0:
+            return []
+
         current_waypoints = list(waypoints)
 
         # Maintain a cache of weights and a lookup of nearest neighbor.

--- a/flanker-core/src/flanker_core/models/vec2.py
+++ b/flanker-core/src/flanker_core/models/vec2.py
@@ -51,9 +51,17 @@ class Vec2:
             self.x * sin_a + self.y * cos_a,
         )
 
+    def is_close(
+        self,
+        other: "Vec2",
+        abs_tol: float = 1e-9,
+        rel_tol: float = 1e-9,
+    ) -> bool:
+        x_close = isclose(self.x, other.x, abs_tol=abs_tol, rel_tol=rel_tol)
+        y_close = isclose(self.y, other.y, abs_tol=abs_tol, rel_tol=rel_tol)
+        return x_close and y_close
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Vec2):
             return NotImplemented
-        x_close = isclose(self.x, other.x, abs_tol=1e-9)
-        y_close = isclose(self.y, other.y, abs_tol=1e-9)
-        return x_close and y_close
+        return self.is_close(other)

--- a/flanker-core/src/flanker_core/systems/move_system.py
+++ b/flanker-core/src/flanker_core/systems/move_system.py
@@ -18,6 +18,9 @@ from flanker_core.systems.initiative_system import InitiativeSystem
 from flanker_core.systems.intersect_system import IntersectSystem
 from flanker_core.systems.los_system import LosSystem
 
+# This is a bandaid fix for LOS polygon imprecision
+_MOVE_INTERRUPT_ATOL = 10
+
 
 @dataclass
 class _MoveActionResult:
@@ -45,7 +48,9 @@ class MoveSystem:
 
     @staticmethod
     def _validate_move(
-        gs: GameState, unit_id: UUID, to: Vec2
+        gs: GameState,
+        unit_id: UUID,
+        to: Vec2,
     ) -> Literal[True] | InvalidAction:
         """Returns `True` if move action can be performed."""
 
@@ -101,7 +106,9 @@ class MoveSystem:
             if interrupt_pos is not None:
                 # If this position already exists, add a the spotter
                 for existing_pos, spotters in interrupt_candidates:
-                    if existing_pos == interrupt_pos:
+                    if existing_pos.is_close(
+                        interrupt_pos, abs_tol=_MOVE_INTERRUPT_ATOL
+                    ):
                         spotters.append(spotter_id)
                         break
                 else:  # Otherwise add a new candidate entry

--- a/scenes/experiment-unabstracted.json
+++ b/scenes/experiment-unabstracted.json
@@ -151,15 +151,7 @@
                 },
                 {
                   "type": "FlagPrune",
-                  "flag_size": 5
-                },
-                {
-                  "type": "WeightsPrune",
-                  "remaining_size": 20
-                },
-                {
-                  "type": "FlagPrune",
-                  "flag_size": 1
+                  "flag_size": 0
                 }
               ]
             }

--- a/scenes/experiment-unabstracted.json
+++ b/scenes/experiment-unabstracted.json
@@ -150,8 +150,7 @@
                   "tolerance": 10
                 },
                 {
-                  "type": "FlagPrune",
-                  "flag_size": 0
+                  "type": "FlagPrune"
                 }
               ]
             }

--- a/scripts/scene-schema.json
+++ b/scripts/scene-schema.json
@@ -278,15 +278,10 @@
           "const": "FlagPrune",
           "title": "Type",
           "type": "string"
-        },
-        "flag_size": {
-          "title": "Flag Size",
-          "type": "integer"
         }
       },
       "required": [
-        "type",
-        "flag_size"
+        "type"
       ],
       "title": "FlagPruneConfig",
       "type": "object"


### PR DESCRIPTION
# Changes
- #219 
  - Fix move interrupt incorrectly assuming a single reactive-fire when it should be two reactive-fires
  - This makes the AI assume that some move actions are peeking, even though they're not
  - The fix is a bandaid fix. 
- #206 
  - Minor changes on pruning and its configs
  - Just spotted some changes that could make AI easier to config