### PR TITLE
Add Experiment Process Pooling

### DIFF
--- a/flanker-core/src/flanker_core/models/components.py
+++ b/flanker-core/src/flanker_core/models/components.py
@@ -70,7 +70,6 @@ class FireControls:
     """
 
     override: FireOutcomes | None = None
-    can_reactive_fire: bool = True
     firing_at: tuple[UUID, FireEffect] | None = None
 
 

--- a/flanker-core/src/flanker_core/systems/fire_system.py
+++ b/flanker-core/src/flanker_core/systems/fire_system.py
@@ -195,7 +195,7 @@ class FireSystem:
         fire_system = gs.get(FireSystem)
 
         unit = gs.get_component(target_id, CombatUnit)
-        for spotter_id, spotter_unit, _, fire_controls in gs.query(
+        for spotter_id, spotter_unit, _, _ in gs.query(
             CombatUnit, Transform, FireControls
         ):
             # Check that spotter is a valid spotter for reactive fire
@@ -204,8 +204,6 @@ class FireSystem:
             if spotter_id == target_id:
                 continue
             if unit.faction == spotter_unit.faction:
-                continue
-            if fire_controls.can_reactive_fire == False:
                 continue
 
             yield spotter_id

--- a/flanker-core/src/flanker_core/systems/initiative_system.py
+++ b/flanker-core/src/flanker_core/systems/initiative_system.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
 from flanker_core.gamestate import GameState
-from flanker_core.models.components import CombatUnit, FireControls, InitiativeState
+from flanker_core.models.components import CombatUnit, InitiativeState
 
 
 class InitiativeSystem:
@@ -16,19 +16,12 @@ class InitiativeSystem:
                     initiative.faction = InitiativeState.Faction.BLUE
                 case InitiativeState.Faction.BLUE:
                     initiative.faction = InitiativeState.Faction.RED
-        # Reset reactive fire
-        for _, fire_controls in gs.query(FireControls):
-            fire_controls.can_reactive_fire = True
 
     @staticmethod
     def set_initiative(gs: GameState, faction: InitiativeState.Faction) -> None:
         """Mutates the given faction to have the initiative."""
         for _, faction_manager in gs.query(InitiativeState):
             faction_manager.faction = faction
-        # Reset reactive fire
-        for _, unit, fire_controls in gs.query(CombatUnit, FireControls):
-            if unit.faction == faction:
-                fire_controls.can_reactive_fire = True
 
     @staticmethod
     def has_initiative(gs: GameState, unit_id: UUID) -> bool:

--- a/flanker-core/src/flanker_core/systems/move_system.py
+++ b/flanker-core/src/flanker_core/systems/move_system.py
@@ -190,8 +190,7 @@ class MoveSystem:
                 )
                 match outcome:
                     case FireOutcomes.MISS:
-                        fire_controls = gs.get_component(spotter_id, FireControls)
-                        fire_controls.can_reactive_fire = False
+                        pass
                     case FireOutcomes.PIN:
                         transform.position = pos
                         if worst_fire_outcome == None:

--- a/flanker-core/tests/test_move_multi_reactive_fire.py
+++ b/flanker-core/tests/test_move_multi_reactive_fire.py
@@ -123,17 +123,9 @@ def test_both_miss(fixture: Fixture) -> None:
     assert transform.position == Vec2(
         20, -10
     ), "Move action expects to not be interrupted"
-    fire_controls = fixture.gs.get_component(fixture.unit_shoot_1, FireControls)
-    assert (
-        fire_controls.can_reactive_fire == False
-    ), "MISS reactive fire results in NO FIRE"
     assert (
         initiative_system.has_initiative(fixture.gs, fixture.unit_shoot_1) == False
     ), "MISS reactive fire mustn't flip initiative"
-    initiative_system.flip_initiative(fixture.gs)
-    assert (
-        fire_controls and fire_controls.can_reactive_fire == True
-    ), "Passing initiative must reset reactive fire"
 
 
 def test_one_pin(fixture: Fixture) -> None:

--- a/flanker-core/tests/test_move_reactive_fire.py
+++ b/flanker-core/tests/test_move_reactive_fire.py
@@ -109,17 +109,9 @@ def test_interrupt_miss(fixture: Fixture) -> None:
     assert transform.position == Vec2(
         20, -10
     ), "Move action expects to not be interrupted"
-    fire_controls = fixture.gs.get_component(fixture.unit_shoot, FireControls)
-    assert (
-        fire_controls.can_reactive_fire == False
-    ), "MISS reactive fire results in NO FIRE"
     assert (
         initiative_system.has_initiative(fixture.gs, fixture.unit_shoot) == False
     ), "MISS reactive fire mustn't flip initiative"
-    initiative_system.flip_initiative(fixture.gs)
-    assert (
-        fire_controls and fire_controls.can_reactive_fire == True
-    ), "Passing initiative must reset reactive fire"
 
 
 def test_interrupt_pin(fixture: Fixture) -> None:
@@ -138,9 +130,6 @@ def test_interrupt_pin(fixture: Fixture) -> None:
     assert (
         initiative_system.has_initiative(fixture.gs, fixture.unit_shoot) == False
     ), "PINNED reactive fire must maintain initiative."
-    assert (
-        fixture.fire_controls.can_reactive_fire == True
-    ), "PINNED reactive fire doesn't mark shooter as NO FIRE"
 
 
 def test_interrupt_suppress(fixture: Fixture) -> None:

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -98,8 +98,8 @@ def run_experiments(
         for experiment in experiments
     }
 
+    # Create a list of matches to work on
     matches: list[tuple[GameState, ExperimentConfig]] = []
-
     for experiment in experiments:
         gs = game_states[str(experiment.scenes)]
         current_tally = get_tally(gs, experiment)
@@ -107,8 +107,11 @@ def run_experiments(
         for _ in range(remaining_matches):
             matches.append((game_states[str(experiment.scenes)], experiment))
 
+    # Randomize to run evenly across all matches
+    random.shuffle(matches)
+
+    # Run this in parallel
     with Pool(processes=max_processes) as p:
-        random.shuffle(matches)
         results = p.imap_unordered(run_match, matches)
         for match_result in results:
             result, experiment = match_result

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -1,4 +1,5 @@
 import random
+from copy import deepcopy
 from dataclasses import is_dataclass
 from inspect import isclass
 from itertools import product
@@ -103,8 +104,9 @@ def run_experiments(
     for experiment in experiments:
         current_tally = get_tally(experiment)
         remaining_matches = max(0, experiment.n_matches - current_tally.n_matches)
+        gs = deepcopy(game_states[str(experiment.scenes)])
         for _ in range(remaining_matches):
-            matches.append((game_states[str(experiment.scenes)], experiment))
+            matches.append((gs, experiment))
 
     # Randomize to run evenly across all matches
     random.shuffle(matches)

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -70,17 +70,21 @@ def run_experiment_set(
     experiment_set: ExperimentSetConfig,
 ) -> None:
 
-    for combination in product(
-        experiment_set.scene_configs,
-        experiment_set.blue_config,
-        experiment_set.red_config,
-        experiment_set.settings_config,
-    ):
-        experiment = ExperimentConfig(
+    experiments: list[ExperimentConfig] = [
+        ExperimentConfig(
             scenes=list(combination),
             n_matches=experiment_set.n_matches,
             parallelization=experiment_set.parallelization,
         )
+        for combination in product(
+            experiment_set.scene_configs,
+            experiment_set.blue_config,
+            experiment_set.red_config,
+            experiment_set.settings_config,
+        )
+    ]
+
+    for experiment in experiments:
         print(
             f"Running experiment {experiment.scenes}",
             f"with {experiment.parallelization} processes",

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -101,8 +101,7 @@ def run_experiments(
     # Create a list of matches to work on
     matches: list[tuple[GameState, ExperimentConfig]] = []
     for experiment in experiments:
-        gs = game_states[str(experiment.scenes)]
-        current_tally = get_tally(gs, experiment)
+        current_tally = get_tally(experiment)
         remaining_matches = max(0, experiment.n_matches - current_tally.n_matches)
         for _ in range(remaining_matches):
             matches.append((game_states[str(experiment.scenes)], experiment))
@@ -116,8 +115,7 @@ def run_experiments(
         for match_result in results:
             result, experiment = match_result
             print(f"    {experiment.scenes} done, tallying")
-            gs = game_states[str(experiment.scenes)]
-            tally = get_tally(gs, experiment)
+            tally = get_tally(experiment)
             if tally.n_matches == experiment.n_matches:
                 continue
             tally.n_matches += 1
@@ -168,7 +166,8 @@ def get_game_state(
     return gs
 
 
-def get_tally(gs: GameState, experiment: ExperimentConfig) -> ExperimentTally:
+def get_tally(experiment: ExperimentConfig) -> ExperimentTally:
+    gs = get_game_state(experiment.scenes)
     file_name = "-".join(experiment.scenes)
     file_path = f"./scripts/experiment_results/{file_name}.json"
     if not Path(file_path).is_file():

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -5,7 +5,6 @@ from inspect import isclass
 from itertools import product
 from multiprocessing.pool import Pool
 from pathlib import Path
-from time import sleep
 from typing import Any
 from uuid import UUID
 
@@ -61,8 +60,8 @@ def main() -> None:
         settings_config=[
             "experiment-settings",
         ],
-        n_matches=20,
-        max_processes=5,
+        n_matches=100,
+        max_processes=14,
     )
     run_experiment_set(my_run)
 

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -1,14 +1,15 @@
-from copy import deepcopy
+import random
 from dataclasses import is_dataclass
 from inspect import isclass
 from itertools import product
-from multiprocessing import Process
+from multiprocessing.pool import Pool
 from pathlib import Path
+from time import sleep
 from typing import Any
 from uuid import UUID
 
 from flanker_ai.ai_agent import AiAgent, AiConfigComponent
-from flanker_ai.ai_match import AiMatch
+from flanker_ai.ai_match import AiMatch, AiMatchResult
 from flanker_core.gamestate import GameState
 from flanker_core.models import components
 from flanker_core.models.components import InitiativeState
@@ -29,7 +30,6 @@ class ExperimentResults(BaseModel):
 class ExperimentConfig(BaseModel):
     n_matches: int
     scenes: list[str]
-    parallelization: int
 
 
 class ExperimentSetConfig(BaseModel):
@@ -38,7 +38,7 @@ class ExperimentSetConfig(BaseModel):
     red_config: list[str]
     settings_config: list[str]
     n_matches: int
-    parallelization: int
+    max_processes: int
 
 
 def main() -> None:
@@ -60,8 +60,8 @@ def main() -> None:
         settings_config=[
             "experiment-settings",
         ],
-        n_matches=100,
-        parallelization=1,
+        n_matches=20,
+        max_processes=5,
     )
     run_experiment_set(my_run)
 
@@ -74,7 +74,6 @@ def run_experiment_set(
         ExperimentConfig(
             scenes=list(combination),
             n_matches=experiment_set.n_matches,
-            parallelization=experiment_set.parallelization,
         )
         for combination in product(
             experiment_set.scene_configs,
@@ -83,54 +82,61 @@ def run_experiment_set(
             experiment_set.settings_config,
         )
     ]
-
-    for experiment in experiments:
-        print(
-            f"Running experiment {experiment.scenes}",
-            f"with {experiment.parallelization} processes",
-        )
-        for _ in range(experiment.parallelization):
-            p = Process(
-                target=run_experiment,
-                args=(experiment,),
-            )
-            p.start()
+    run_experiments(
+        experiments,
+        max_processes=experiment_set.max_processes,
+    )
 
 
-def run_experiment(
-    experiment: ExperimentConfig,
+def run_experiments(
+    experiments: list[ExperimentConfig],
+    max_processes: int,
 ) -> None:
 
-    paths = [f"./scenes/{scene}.json" for scene in experiment.scenes]
-    gs = get_game_state(paths=paths)
+    game_states: dict[str, GameState] = {
+        str(experiment.scenes): get_game_state(experiment.scenes)
+        for experiment in experiments
+    }
 
-    experiment_name = "-".join(experiment.scenes)
-    record_file = f"./scripts/experiment_results/{experiment_name}.json"
+    matches: list[tuple[GameState, ExperimentConfig]] = [
+        (game_states[str(experiment.scenes)], experiment)
+        for experiment in experiments
+        for _ in range(experiment.n_matches)
+    ]
 
-    # Initialize the file if not exist
-    tally = get_current_result(gs, record_file)
-    save_result(record_file, tally)
+    with Pool(processes=max_processes) as p:
+        random.shuffle(matches)
+        # FIXME: there is no trial size limit. This can go over-sized
+        results = p.imap_unordered(run_match, matches)
+        for match_result in results:
+            result, gs, experiment = match_result
+            print(f"{experiment.scenes} done, tallying")
+            experiment_name = "-".join(experiment.scenes)
+            record_file = f"./scripts/experiment_results/{experiment_name}.json"
+            tally = get_current_result(gs, record_file)
+            tally.n_matches += 1
+            match result.winner:
+                case None:
+                    tally.draws += 1
+                case InitiativeState.Faction.BLUE:
+                    tally.blue_wins += 1
+                case InitiativeState.Faction.RED:
+                    tally.red_wins += 1
+            save_result(record_file, tally)
 
-    while tally.n_matches < experiment.n_matches:
-        new_gs = deepcopy(gs)
-        result = AiMatch.run_match(new_gs)
-        # TODO do I need parallel safe tallying operation?
-        tally = get_current_result(gs, record_file)  # Resync a new tally
-        tally.n_matches += 1
-        if tally.n_matches > experiment.n_matches:
-            break
-        match result.winner:
-            case None:
-                tally.draws += 1
-            case InitiativeState.Faction.BLUE:
-                tally.blue_wins += 1
-            case InitiativeState.Faction.RED:
-                tally.red_wins += 1
-        save_result(record_file, tally)
+
+def run_match(
+    match: tuple[GameState, ExperimentConfig],
+) -> tuple[AiMatchResult, GameState, ExperimentConfig]:
+    gs, experiment = match
+    print(f"Running experiment {experiment.scenes}")
+    result = AiMatch.run_match(gs)
+    sleep(0.1)
+    return result, gs, experiment
 
 
 def get_game_state(
-    paths: list[str],
+    scenes: list[str],
 ) -> GameState:
     component_types: list[type[Any]] = []
     component_types.append(AiConfigComponent)
@@ -139,6 +145,7 @@ def get_game_state(
             component_types.append(cls)
 
     entities: dict[UUID, Any] = {}
+    paths = [f"./scenes/{scene}.json" for scene in scenes]
     for path in paths:
         with open(path, "r") as f:
             entities.update(

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -101,10 +101,8 @@ def run_experiments(
     matches: list[tuple[GameState, ExperimentConfig]] = []
 
     for experiment in experiments:
-        experiment_name = "-".join(experiment.scenes)
-        record_file = f"./scripts/experiment_results/{experiment_name}.json"
         gs = game_states[str(experiment.scenes)]
-        current_tally = get_tally(gs, record_file)
+        current_tally = get_tally(gs, experiment)
         remaining_matches = max(0, experiment.n_matches - current_tally.n_matches)
         for _ in range(remaining_matches):
             matches.append((game_states[str(experiment.scenes)], experiment))
@@ -114,11 +112,9 @@ def run_experiments(
         results = p.imap_unordered(run_match, matches)
         for match_result in results:
             result, experiment = match_result
-            print(f"{experiment.scenes} done, tallying")
-            experiment_name = "-".join(experiment.scenes)
-            record_file = f"./scripts/experiment_results/{experiment_name}.json"
+            print(f"    {experiment.scenes} done, tallying")
             gs = game_states[str(experiment.scenes)]
-            tally = get_tally(gs, record_file)
+            tally = get_tally(gs, experiment)
             if tally.n_matches == experiment.n_matches:
                 continue
             tally.n_matches += 1
@@ -129,7 +125,7 @@ def run_experiments(
                     tally.blue_wins += 1
                 case InitiativeState.Faction.RED:
                     tally.red_wins += 1
-            save_tally(record_file, tally)
+            save_tally(experiment, tally)
 
 
 def run_match(
@@ -169,11 +165,10 @@ def get_game_state(
     return gs
 
 
-def get_tally(
-    gs: GameState,
-    record_file: str,
-) -> ExperimentTally:
-    if not Path(record_file).is_file():
+def get_tally(gs: GameState, experiment: ExperimentConfig) -> ExperimentTally:
+    file_name = "-".join(experiment.scenes)
+    file_path = f"./scripts/experiment_results/{file_name}.json"
+    if not Path(file_path).is_file():
         blue_config: AiConfigComponent | None = None
         red_config: AiConfigComponent | None = None
         for _, config in gs.query(AiConfigComponent):
@@ -195,15 +190,17 @@ def get_tally(
             red_config=red_config,
         )
 
-    with open(record_file, "r") as f:
+    with open(file_path, "r") as f:
         return ExperimentTally.model_validate_json(f.read())
 
 
 def save_tally(
-    record_file: str,
+    experiment: ExperimentConfig,
     result: ExperimentTally,
 ) -> None:
-    with open(record_file, "w") as f:
+    file_name = "-".join(experiment.scenes)
+    file_path = f"./scripts/experiment_results/{file_name}.json"
+    with open(file_path, "w") as f:
         f.write(result.model_dump_json(indent=2))
 
 

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -109,10 +109,11 @@ def run_experiments(
         # FIXME: there is no trial size limit. This can go over-sized
         results = p.imap_unordered(run_match, matches)
         for match_result in results:
-            result, gs, experiment = match_result
+            result, experiment = match_result
             print(f"{experiment.scenes} done, tallying")
             experiment_name = "-".join(experiment.scenes)
             record_file = f"./scripts/experiment_results/{experiment_name}.json"
+            gs = game_states[str(experiment.scenes)]
             tally = get_current_result(gs, record_file)
             tally.n_matches += 1
             match result.winner:
@@ -127,12 +128,12 @@ def run_experiments(
 
 def run_match(
     match: tuple[GameState, ExperimentConfig],
-) -> tuple[AiMatchResult, GameState, ExperimentConfig]:
+) -> tuple[AiMatchResult, ExperimentConfig]:
     gs, experiment = match
     print(f"Running experiment {experiment.scenes}")
     result = AiMatch.run_match(gs)
     sleep(0.1)
-    return result, gs, experiment
+    return result, experiment
 
 
 def get_game_state(

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -137,7 +137,6 @@ def run_match(
     gs, experiment = match
     print(f"Running experiment {experiment.scenes}")
     result = AiMatch.run_match(gs)
-    sleep(0.1)
     return result, experiment
 
 

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -18,7 +18,7 @@ from flanker_core.systems.register_systems import register_systems
 from pydantic import BaseModel
 
 
-class ExperimentResults(BaseModel):
+class ExperimentTally(BaseModel):
     n_matches: int
     blue_wins: int
     red_wins: int
@@ -114,7 +114,7 @@ def run_experiments(
             experiment_name = "-".join(experiment.scenes)
             record_file = f"./scripts/experiment_results/{experiment_name}.json"
             gs = game_states[str(experiment.scenes)]
-            tally = get_current_result(gs, record_file)
+            tally = get_tally(gs, record_file)
             tally.n_matches += 1
             match result.winner:
                 case None:
@@ -123,7 +123,7 @@ def run_experiments(
                     tally.blue_wins += 1
                 case InitiativeState.Faction.RED:
                     tally.red_wins += 1
-            save_result(record_file, tally)
+            save_tally(record_file, tally)
 
 
 def run_match(
@@ -163,10 +163,10 @@ def get_game_state(
     return gs
 
 
-def get_current_result(
+def get_tally(
     gs: GameState,
     record_file: str,
-) -> ExperimentResults:
+) -> ExperimentTally:
     if not Path(record_file).is_file():
         blue_config: AiConfigComponent | None = None
         red_config: AiConfigComponent | None = None
@@ -180,7 +180,7 @@ def get_current_result(
         if red_config == None:
             raise Exception("AI config is missing for RED.")
 
-        return ExperimentResults(
+        return ExperimentTally(
             n_matches=0,
             blue_wins=0,
             red_wins=0,
@@ -190,12 +190,12 @@ def get_current_result(
         )
 
     with open(record_file, "r") as f:
-        return ExperimentResults.model_validate_json(f.read())
+        return ExperimentTally.model_validate_json(f.read())
 
 
-def save_result(
+def save_tally(
     record_file: str,
-    result: ExperimentResults,
+    result: ExperimentTally,
 ) -> None:
     with open(record_file, "w") as f:
         f.write(result.model_dump_json(indent=2))

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -98,15 +98,19 @@ def run_experiments(
         for experiment in experiments
     }
 
-    matches: list[tuple[GameState, ExperimentConfig]] = [
-        (game_states[str(experiment.scenes)], experiment)
-        for experiment in experiments
-        for _ in range(experiment.n_matches)
-    ]
+    matches: list[tuple[GameState, ExperimentConfig]] = []
+
+    for experiment in experiments:
+        experiment_name = "-".join(experiment.scenes)
+        record_file = f"./scripts/experiment_results/{experiment_name}.json"
+        gs = game_states[str(experiment.scenes)]
+        current_tally = get_tally(gs, record_file)
+        remaining_matches = max(0, experiment.n_matches - current_tally.n_matches)
+        for _ in range(remaining_matches):
+            matches.append((game_states[str(experiment.scenes)], experiment))
 
     with Pool(processes=max_processes) as p:
         random.shuffle(matches)
-        # FIXME: there is no trial size limit. This can go over-sized
         results = p.imap_unordered(run_match, matches)
         for match_result in results:
             result, experiment = match_result
@@ -115,6 +119,8 @@ def run_experiments(
             record_file = f"./scripts/experiment_results/{experiment_name}.json"
             gs = game_states[str(experiment.scenes)]
             tally = get_tally(gs, record_file)
+            if tally.n_matches == experiment.n_matches:
+                continue
             tally.n_matches += 1
             match result.winner:
                 case None:

--- a/webapi/combat_unit_service.py
+++ b/webapi/combat_unit_service.py
@@ -57,7 +57,6 @@ class CombatUnitService:
                     degree=transform.degrees,
                     status=fire_system.get_status(gs, unit_id),
                     is_friendly=(unit.faction == faction),
-                    no_fire=not fire_controls.can_reactive_fire,
                     firing_at=fire_controls.firing_at,
                 )
             )

--- a/webapi/models.py
+++ b/webapi/models.py
@@ -25,7 +25,6 @@ class SquadModel(BaseModel, CamelCaseConfig):
     degree: float
     status: CombatUnit.Status
     is_friendly: bool
-    no_fire: bool
     firing_at: tuple[UUID, FireEffect] | None
 
 

--- a/webui/src/lib/api-schema.d.ts
+++ b/webui/src/lib/api-schema.d.ts
@@ -178,8 +178,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Ai Play */
-        post: operations["ai_play_api__sceneName___gameId__ai_play_post"];
+        /** Run Match */
+        post: operations["run_match_api__sceneName___gameId__ai_play_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -394,8 +394,6 @@ export interface components {
             status: components["schemas"]["Status"];
             /** Isfriendly */
             isFriendly: boolean;
-            /** Nofire */
-            noFire: boolean;
             /** Firingat */
             firingAt: [
                 string,
@@ -800,7 +798,7 @@ export interface operations {
             };
         };
     };
-    ai_play_api__sceneName___gameId__ai_play_post: {
+    run_match_api__sceneName___gameId__ai_play_post: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
# Changes
- #231 
  - This was a long running task, at once it's done (not fully)
  - Added process pool to limit the number of processes
  - Added `matches: list[tuple[GameState, ExperimentConfig]]` list, randomly shuffled, for the pool to process. This ensures even processing for each experiment.
  - Refactored file tallying to centralized. Should prevent bugs
  - I feel like this is a less sturdy implementation than before, but I like it more. Cleaner and easier to work with, albeit more that can go wrong. Perhaps I need test cases.
- #229 
  - removed NOFIRE penalty. I'm freee!!!