### PR TITLE
Add AI Match Runtime Cap

### DIFF
--- a/flanker-ai/src/flanker_ai/ai_match.py
+++ b/flanker-ai/src/flanker_ai/ai_match.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from time import perf_counter
 
 from flanker_ai.actions import ActionResult
 from flanker_ai.ai_agent import AiAgent
@@ -6,9 +7,12 @@ from flanker_core.gamestate import GameState
 from flanker_core.models.components import InitiativeState
 from flanker_core.systems.objective_system import ObjectiveSystem
 
+MAX_RUNTIME_SECONDS = 360
+
 
 @dataclass
 class AiMatchResult:
+    runtime: float
     action_results: list[ActionResult]
     winner: InitiativeState.Faction | None
     blue_search_size: int
@@ -41,8 +45,16 @@ class AiMatch:
 
         # Let two agents fight each other over and over
         action_results: list[ActionResult] = []
+        start_time = perf_counter()
         objective_system = gs.get(ObjectiveSystem)
         while (winner := objective_system.get_winning_faction(gs)) == None:
+
+            # Max safety time limit per run so it doesn't consume CPU.
+            runtime = perf_counter() - start_time
+            if runtime > MAX_RUNTIME_SECONDS:
+                break
+
+            # Have the AI play agianst each other.
             blue_action_results = blue_agent.play_initiative(
                 callback=count_blue_search_size,
             )
@@ -55,7 +67,9 @@ class AiMatch:
             if not red_action_results and not blue_action_results:
                 break
 
+        runtime = perf_counter() - start_time
         return AiMatchResult(
+            runtime=runtime,
             action_results=action_results,
             winner=winner,
             blue_search_size=blue_search_size,

--- a/scripts/ai_perf_test.py
+++ b/scripts/ai_perf_test.py
@@ -2,6 +2,7 @@ import random
 from dataclasses import is_dataclass
 from inspect import isclass
 from typing import Any
+from uuid import UUID
 
 from flanker_ai.ai_agent import AiAgent
 from flanker_ai.ai_match import AiMatch
@@ -12,28 +13,39 @@ from flanker_core.serializer import Serializer
 from flanker_core.systems.register_systems import register_systems
 
 
-def load_state(path: str) -> GameState:
-
+def get_game_state(
+    paths: list[str],
+) -> GameState:
     component_types: list[type[Any]] = []
+    component_types.append(AiConfigComponent)
     for _, cls in vars(components).items():
         if isclass(cls) and is_dataclass(cls):
             component_types.append(cls)
-    component_types.append(AiConfigComponent)
 
-    with open(path, "r") as f:
-        entities = Serializer.deserialize(
-            json_data=f.read(),
-            component_types=component_types,
-        )
-        gs = GameState.load(entities)
+    entities: dict[UUID, Any] = {}
+    for path in paths:
+        with open(path, "r") as f:
+            entities.update(
+                Serializer.deserialize(
+                    json_data=f.read(),
+                    component_types=component_types,
+                )
+            )
 
+    gs = GameState.load(entities)
     register_systems(gs)
     return gs
 
 
 if __name__ == "__main__":
-    PATH = "./scenes/experiment-analysis.json"
-    gs = load_state(PATH)
+    gs = get_game_state(
+        paths=[
+            "./scenes/experiment-settings.json",
+            "./scenes/experiment-scene-2.json",
+            "./scenes/experiment-blue-analysis-weak.json",
+            "./scenes/experiment-red-rh.json",
+        ]
+    )
 
     # Ensures that each run is consistent in search size
     random.seed(10)

--- a/scripts/run_ai_experiment.py
+++ b/scripts/run_ai_experiment.py
@@ -5,7 +5,6 @@ from inspect import isclass
 from itertools import product
 from multiprocessing.pool import Pool
 from pathlib import Path
-from time import perf_counter
 from typing import Any
 from uuid import UUID
 
@@ -137,13 +136,11 @@ def run_match(
 ) -> tuple[MatchResult, ExperimentConfig]:
     gs, experiment = match
     print(f"Running match {experiment.name}")
-    start_time = perf_counter()
     result: AiMatchResult = AiMatch.run_match(gs)
-    end_time = perf_counter()
     return (
         MatchResult(
             winner=result.winner,
-            total_runtime=end_time - start_time,
+            total_runtime=result.runtime,
             blue_search_size=result.blue_search_size,
             red_search_size=result.red_search_size,
         ),


### PR DESCRIPTION
# Changes
- #239 
  - With new recorded variables, I see some matches running ludicrously long
  - Those matches go up 10+ minutes, even 30 or 40 minutes
  - They cost an entire CPU. Not ideal.
  - Added time limit for each match. It will break early and consider draw if time runs out.
  - Will need to rerun experiments with this.